### PR TITLE
enable community notice

### DIFF
--- a/views/community.html
+++ b/views/community.html
@@ -91,8 +91,7 @@
     </table>
 
     <p class="mt-3 mt-md-6">
-      <!-- TODO: enable when neo branch becomes master -->
-      <!-- {{{localized.community.meetup_notice}}} -->
+      {{{localized.community.meetup_notice}}}
     </p>
   </div>
 </section>


### PR DESCRIPTION
Now that master is the default branch, we can deep link to the right file for editing meetups.