### PR TITLE
electron.atom.io → electronjs.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to electron.atom.io
+# Contributing to electronjs.org
 
 :+1::tada: Thanks for taking the time to contribute! :tada::+1:
 
@@ -28,7 +28,7 @@ feel free to propose changes to this document in a pull request.
 
 ## Issues and Pull Requests
 
-* If you're not sure about adding something, [open an issue](https://github.com/electron/electron.atom.io/issues/new) to discuss it.
+* If you're not sure about adding something, [open an issue](https://github.com/electron/electronjs.org/issues/new) to discuss it.
 * Feel free to open a Pull Request early so that a discussion can be had as changes are developed.
 * Include screenshots and animated gifs of your changes whenever possible.
 
@@ -48,8 +48,8 @@ When pull request is closed or merged, the ephemeral app is destroyed.
 Follow these steps to copy this repository to your computer and build the site:
 
 ```bash
-git clone https://github.com/electron/electron.atom.io
-cd electron.atom.io
+git clone https://github.com/electron/electronjs.org
+cd electronjs.org
 npm install
 npm run dev
 ```
@@ -107,7 +107,7 @@ The [/data/locale.yml](/data/locale.yml) file contains English strings that
 are used throughout the site. This file is synced with Crowdin as part of 
 the [translation](#translations) pipeline. These strings are displayed on the 
 site in the visitor's target language if available, with a 
-[fallback to the English value](https://github.com/electron/electron.atom.io/blob/ec9d8a55420d33a7a4145ae9c7b08da559de839d/lib/i18n.js#L10-L19) 
+[fallback to the English value](https://github.com/electron/electronjs.org/blob/ec9d8a55420d33a7a4145ae9c7b08da559de839d/lib/i18n.js#L10-L19) 
 if no translation exists yet.
 
 To use localized strings in views, use the `localized` object, which is generated
@@ -300,5 +300,5 @@ file. To list all available commands, type `npm run`.
 ## Need Help?
 
 If any of this information confusing, incorrect, or incomplete, feel free to 
-[open an issue](https://github.com/electron/electron.atom.io/issues/new)
+[open an issue](https://github.com/electron/electronjs.org/issues/new)
 for help.

--- a/data/blog/accessibility-tools.md
+++ b/data/blog/accessibility-tools.md
@@ -4,13 +4,13 @@ author: jlord
 date: '2016-08-23'
 ---
 
-Making accessible applications is important and we're happy to introduce new functionality to [Devtron](http://electron.atom.io/devtron) and [Spectron](http://electron.atom.io/spectron) that gives developers the opportunity to make their apps better for everyone.
+Making accessible applications is important and we're happy to introduce new functionality to [Devtron](https://electronjs.org/devtron) and [Spectron](https://electronjs.org/spectron) that gives developers the opportunity to make their apps better for everyone.
 
 ---
 
 Accessibility concerns in Electron applications are similar to those of websites because they're both ultimately HTML. With Electron apps, however, you can't use the online resources for accessibility audits because your app doesn't have a URL to point the auditor to.
 
-These new features bring those auditing tools to your Electron app. You can choose to add audits to your tests with Spectron or use them within DevTools with Devtron. Read on for a summary of the tools or checkout our [accessibility documentation](http://electron.atom.io/docs/tutorial/accessibility/) for more information.
+These new features bring those auditing tools to your Electron app. You can choose to add audits to your tests with Spectron or use them within DevTools with Devtron. Read on for a summary of the tools or checkout our [accessibility documentation](https://electronjs.org/docs/tutorial/accessibility/) for more information.
 
 ### Spectron
 
@@ -34,5 +34,5 @@ In Devtron there is a new accessibility tab which will allow you to audit a page
 
 Both of these tools are using the [Accessibility Developer Tools](https://github.com/GoogleChrome/accessibility-developer-tools) library built by Google for Chrome. You can learn more about the accessibility audit rules this library uses on that [repository's wiki](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules).
 
-If you know of other great accessibility tools for Electron, add them to the [accessibility documentation](http://electron.atom.io/docs/tutorial/accessibility/) with a pull request.
+If you know of other great accessibility tools for Electron, add them to the [accessibility documentation](https://electronjs.org/docs/tutorial/accessibility/) with a pull request.
 

--- a/data/blog/api-docs-json-schema.md
+++ b/data/blog/api-docs-json-schema.md
@@ -31,7 +31,7 @@ Here's an excerpt from the schema that describes the `BrowserWindow` class:
   type: 'Class',
   instanceName: 'win',
   slug: 'browser-window',
-  websiteUrl: 'http://electron.atom.io/docs/api/browser-window',
+  websiteUrl: 'https://electronjs.org/docs/api/browser-window',
   repoUrl: 'https://github.com/electron/electron/blob/v1.4.0/docs/api/browser-window.md',
   staticMethods: [...],
   instanceMethods: [...],
@@ -118,7 +118,7 @@ have contributed to the docs.
 We're excited to see what people do with this new structured data. Possible uses
 include:
 
-- Improvements to [electron.atom.io/docs/](http://electron.atom.io/docs/)
+- Improvements to [electron.atom.io/docs/](https://electronjs.org/docs/)
 - A [TypeScript definition file](https://github.com/electron/electron-docs-linter/blob/master/README.md#typescript-definitions) for more streamlined Electron development in projects using TypeScript.
 - Searchable offline documentation for tools like [Dash.app](https://kapeli.com/dash) and [devdocs.io](http://devdocs.io/)
 

--- a/data/blog/api-docs-json-schema.md
+++ b/data/blog/api-docs-json-schema.md
@@ -118,7 +118,7 @@ have contributed to the docs.
 We're excited to see what people do with this new structured data. Possible uses
 include:
 
-- Improvements to [electron.atom.io/docs/](https://electronjs.org/docs/)
+- Improvements to [https://electronjs.org/docs/](https://electronjs.org/docs/)
 - A [TypeScript definition file](https://github.com/electron/electron-docs-linter/blob/master/README.md#typescript-definitions) for more streamlined Electron development in projects using TypeScript.
 - Searchable offline documentation for tools like [Dash.app](https://kapeli.com/dash) and [devdocs.io](http://devdocs.io/)
 

--- a/data/blog/august-2016-roundup.md
+++ b/data/blog/august-2016-roundup.md
@@ -8,7 +8,7 @@ Here are the new Electron apps that were added to the site in August.
 
 ---
 
-The site is updated with new [apps](http://electron.atom.io/apps) and [meetups](http://electron.atom.io/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](http://electron.atom.io/feed.xml).
+The site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
 If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
 

--- a/data/blog/august-2016-roundup.md
+++ b/data/blog/august-2016-roundup.md
@@ -8,9 +8,9 @@ Here are the new Electron apps that were added to the site in August.
 
 ---
 
-The site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
+The site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electronjs.org/pulls) from the community. You can [watch the repository](https://github.com/electron/electronjs.org) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
-If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
+If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electronjs.org) to add it to the site and it will make the next roundup.
 
 ### New Apps
 

--- a/data/blog/chromium-rce-vulnerability.md
+++ b/data/blog/chromium-rce-vulnerability.md
@@ -23,5 +23,5 @@ see our [security tutorial].
 Please contact electron@github.com if you wish to report a vulnerability in
 Electron.
 
-[sandbox option]: https://electron.atom.io/docs/api/sandbox-option
-[security tutorial]: https://electron.atom.io/docs/tutorial/security
+[sandbox option]: https://electronjs.org/docs/api/sandbox-option
+[security tutorial]: https://electronjs.org/docs/tutorial/security

--- a/data/blog/electron-1-0.md
+++ b/data/blog/electron-1-0.md
@@ -7,7 +7,7 @@ date: '2016-05-11'
 For the last two years, Electron has helped developers build cross platform
 desktop apps using HTML, CSS, and JavaScript. Now we're excited to share a major
 milestone for our framework and for the community that created it. The release
-of Electron 1.0 is now available from [electron.atom.io][electron.atom.io].
+of Electron 1.0 is now available from [electronjs.org][electronjs.org].
 
 ---
 
@@ -103,7 +103,7 @@ New to Electron? Watch the Electron 1.0 intro video:
 [community]: https://electronjs.org/community
 [devtools]: https://developer.chrome.com/devtools
 [devtron]: https://electronjs.org/devtron
-[electron.atom.io]: https://electronjs.org
+[electronjs.org]: https://electronjs.org
 [electron-api-demos]: https://github.com/electron/electron-api-demos
 [electron-org]: https://github.com/electron
 [electron-userland]: https://github.com/electron-userland

--- a/data/blog/electron-1-0.md
+++ b/data/blog/electron-1-0.md
@@ -97,22 +97,22 @@ New to Electron? Watch the Electron 1.0 intro video:
 
 <div class="video"><iframe src="https://www.youtube.com/embed/8YP_nOCO-4Q?rel=0" frameborder="0" allowfullscreen></iframe></div>
 
-[apps]: http://electron.atom.io/apps
+[apps]: https://electronjs.org/apps
 [atom]: https://atom.io
 [chromedriver]: https://sites.google.com/a/chromium.org/chromedriver
-[community]: http://electron.atom.io/community
+[community]: https://electronjs.org/community
 [devtools]: https://developer.chrome.com/devtools
-[devtron]: http://electron.atom.io/devtron
-[electron.atom.io]: http://electron.atom.io
+[devtron]: https://electronjs.org/devtron
+[electron.atom.io]: https://electronjs.org
 [electron-api-demos]: https://github.com/electron/electron-api-demos
 [electron-org]: https://github.com/electron
 [electron-userland]: https://github.com/electron-userland
 [gitkraken]: https://www.gitkraken.com
 [jibo]: https://www.jibo.com
 [nylas]: https://nylas.com
-[quick-start]: http://electron.atom.io/docs/tutorial/quick-start
+[quick-start]: https://electronjs.org/docs/tutorial/quick-start
 [slack]: https://slack.com
-[spectron]: http://electron.atom.io/spectron
+[spectron]: https://electronjs.org/spectron
 [wagon]: https://www.wagonhq.com
 [webtorrent]: https://webtorrent.io/desktop
 [webdriver]: http://webdriver.io

--- a/data/blog/electron-doumentation.md
+++ b/data/blog/electron-doumentation.md
@@ -4,15 +4,15 @@ author: jlord
 date: '2015-06-04'
 ---
 
-This week we've given Electron's documentation a home on [electron.atom.io](http://electron.atom.io). You can visit [/docs/latest](http://electron.atom.io/docs/latest) for the latest set of docs. We'll keep versions of older docs, too, so you're able to visit [/docs/vX.XX.X](http://electron.atom.io/docs/v0.26.0) for the docs that correlate to the version you're using.
+This week we've given Electron's documentation a home on [electron.atom.io](https://electronjs.org). You can visit [/docs/latest](https://electronjs.org/docs/latest) for the latest set of docs. We'll keep versions of older docs, too, so you're able to visit [/docs/vX.XX.X](https://electronjs.org/docs/v0.26.0) for the docs that correlate to the version you're using.
 
 ---
 
-You can visit [/docs](http://electron.atom.io/docs) to see what versions are available or [/docs/all](http://electron.atom.io/docs/all) to see the latest version of docs all on one page (nice for `cmd` + `f` searches).
+You can visit [/docs](https://electronjs.org/docs) to see what versions are available or [/docs/all](https://electronjs.org/docs/all) to see the latest version of docs all on one page (nice for `cmd` + `f` searches).
 
 If you'd like to contribute to the docs content, you can do so in the [Electron repository](https://github.com/electron/electron/tree/master/docs), where the docs are fetched from. We fetch them for each minor release and add them to the [Electron site repository](http://github.com/electron/electron.atom.io), which is made with [Jekyll](http://jekyllrb.com).
 
-If you're interested in learning more about how we pull the docs from one repository to another continue reading below. Otherwise, enjoy the [docs](http://electron.atom.io/latest)!
+If you're interested in learning more about how we pull the docs from one repository to another continue reading below. Otherwise, enjoy the [docs](https://electronjs.org/latest)!
 
 ## The Technical Bits
 
@@ -75,7 +75,7 @@ collections:
     docs: {output: true, permalink: '/docs/:path/'}
 ```
 
-The file `latest.md` in our site root is empty except for this front matter which allows users to see the index (aka `README`) of the latest version of docs by visiting this URL, [electron.atom.io/docs/latest](http://electron.atom.io/docs/latest), rather than using the latest version number specifically (though you can do that, too).
+The file `latest.md` in our site root is empty except for this front matter which allows users to see the index (aka `README`) of the latest version of docs by visiting this URL, [electron.atom.io/docs/latest](https://electronjs.org/docs/latest), rather than using the latest version number specifically (though you can do that, too).
 
 ```yaml
 ---

--- a/data/blog/electron-doumentation.md
+++ b/data/blog/electron-doumentation.md
@@ -4,29 +4,29 @@ author: jlord
 date: '2015-06-04'
 ---
 
-This week we've given Electron's documentation a home on [electron.atom.io](https://electronjs.org). You can visit [/docs/latest](https://electronjs.org/docs/latest) for the latest set of docs. We'll keep versions of older docs, too, so you're able to visit [/docs/vX.XX.X](https://electronjs.org/docs/v0.26.0) for the docs that correlate to the version you're using.
+This week we've given Electron's documentation a home on [electronjs.org](https://electronjs.org). You can visit [/docs/latest](https://electronjs.org/docs/latest) for the latest set of docs. We'll keep versions of older docs, too, so you're able to visit [/docs/vX.XX.X](https://electronjs.org/docs/v0.26.0) for the docs that correlate to the version you're using.
 
 ---
 
 You can visit [/docs](https://electronjs.org/docs) to see what versions are available or [/docs/all](https://electronjs.org/docs/all) to see the latest version of docs all on one page (nice for `cmd` + `f` searches).
 
-If you'd like to contribute to the docs content, you can do so in the [Electron repository](https://github.com/electron/electron/tree/master/docs), where the docs are fetched from. We fetch them for each minor release and add them to the [Electron site repository](http://github.com/electron/electron.atom.io), which is made with [Jekyll](http://jekyllrb.com).
+If you'd like to contribute to the docs content, you can do so in the [Electron repository](https://github.com/electron/electron/tree/master/docs), where the docs are fetched from. We fetch them for each minor release and add them to the [Electron site repository](http://github.com/electron/electronjs.org), which is made with [Jekyll](http://jekyllrb.com).
 
 If you're interested in learning more about how we pull the docs from one repository to another continue reading below. Otherwise, enjoy the [docs](https://electronjs.org/latest)!
 
 ## The Technical Bits
 
-We're preserving the documentation within the Electron core repository as is. This means that [electron/electron](http://github.com/electron/electron) will always have the latest version of the docs. When new versions of Electron are released, we duplicate them over on the Electron website repository, [electron/electron.atom.io](http://github.com/electron/electron.atom.io).
+We're preserving the documentation within the Electron core repository as is. This means that [electron/electron](http://github.com/electron/electron) will always have the latest version of the docs. When new versions of Electron are released, we duplicate them over on the Electron website repository, [electron/electronjs.org](http://github.com/electron/electronjs.org).
 
 ### script/docs
 
-To fetch the docs we run a [script](https://github.com/electron/electron.atom.io/blob/0205b5ab26c96a95121bc564c5824f92108677e0/script/docs) with a command line interface of `script/docs vX.XX.X` with or without the `--latest` option (depending on if the version you're importing is the latest version). Our [script for fetching docs](https://github.com/electron/electron.atom.io/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js) uses a few interesting Node modules:
+To fetch the docs we run a [script](https://github.com/electron/electronjs.org/blob/0205b5ab26c96a95121bc564c5824f92108677e0/script/docs) with a command line interface of `script/docs vX.XX.X` with or without the `--latest` option (depending on if the version you're importing is the latest version). Our [script for fetching docs](https://github.com/electron/electronjs.org/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js) uses a few interesting Node modules:
 
-- [`nugget`](http://npmjs.com/nugget) for [getting the release tarball](https://github.com/electron/electron.atom.io/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L40-L43) and saving it to a temporay directory.
-- [`gunzip-maybe`](http://npmsjs.com/gunzip-maybe) to [unzip the tarball](https://github.com/electron/electron.atom.io/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L95).
-- [`tar-fs`](http://npmjs.com/tar-fs) for [streaming just the `/docs` directory](https://github.com/electron/electron.atom.io/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L63-L65) from the tarball and [filtering and processing the files](https://github.com/electron/electron.atom.io/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L68-L78) (with the help of [`through2`](http://npmjs.com/through2)) so that they work nicely with our Jekyll site (more on that below).
+- [`nugget`](http://npmjs.com/nugget) for [getting the release tarball](https://github.com/electron/electronjs.org/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L40-L43) and saving it to a temporay directory.
+- [`gunzip-maybe`](http://npmsjs.com/gunzip-maybe) to [unzip the tarball](https://github.com/electron/electronjs.org/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L95).
+- [`tar-fs`](http://npmjs.com/tar-fs) for [streaming just the `/docs` directory](https://github.com/electron/electronjs.org/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L63-L65) from the tarball and [filtering and processing the files](https://github.com/electron/electronjs.org/blob/0205b5ab26c96a95121bc564c5824f92108677e0/lib/fetch-docs.js#L68-L78) (with the help of [`through2`](http://npmjs.com/through2)) so that they work nicely with our Jekyll site (more on that below).
 
-[Tests](https://github.com/electron/electron.atom.io/tree/gh-pages/spec) help us know that all the bits and pieces landed as expected.
+[Tests](https://github.com/electron/electronjs.org/tree/gh-pages/spec) help us know that all the bits and pieces landed as expected.
 
 ### Jekyll
 

--- a/data/blog/electron-internals-using-node-as-a-library.md
+++ b/data/blog/electron-internals-using-node-as-a-library.md
@@ -109,7 +109,7 @@ in a future post.
 [v8-expose]: https://github.com/electron/libchromiumcontent/blob/v51.0.2704.61/chromiumcontent/chromiumcontent.gypi#L104-L122
 [libuv-expose]: https://github.com/electron/electron/blob/v1.3.2/common.gypi#L219-L228
 [node-start]: https://github.com/nodejs/node/blob/v6.3.1/src/node.h#L187-L191
-[event-loop]: http://electron.atom.io/blog/2016/07/28/electron-internals-node-integration
+[event-loop]: https://electronjs.org/blog/2016/07/28/electron-internals-node-integration
 [gyp-docs]: https://gyp.gsrc.io/docs/UserDocumentation.md
 [native-modules]: https://nodejs.org/api/addons.html
 [boringssl]: https://boringssl.googlesource.com/boringssl

--- a/data/blog/electron-internals-weak-references.md
+++ b/data/blog/electron-internals-weak-references.md
@@ -211,7 +211,7 @@ The `createIDWeakMap` API:
 * [`key_weak_map.h`](https://github.com/electron/electron/blob/v1.3.4/atom/common/key_weak_map.h)
 * [`atom_api_key_weak_map.h`](https://github.com/electron/electron/blob/v1.3.4/atom/common/api/atom_api_key_weak_map.h)
 
-[window-disappearing]: http://electron.atom.io/docs/faq/#my-apps-windowtray-disappeared-after-a-few-minutes
+[window-disappearing]: https://electronjs.org/docs/faq/#my-apps-windowtray-disappeared-after-a-few-minutes
 [WeakMap]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 [remote-procedure-call]: https://en.wikipedia.org/wiki/Remote_procedure_call
 

--- a/data/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
+++ b/data/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
@@ -17,7 +17,7 @@ As of `v0.34.0` each Electron release includes a build compatible with the Mac A
 - `crash-reporter`
 - `auto-updater`
 
-Additionally some behaviors have changed with respect to detecting DNS changes, video capture and accessibility features. You can read more about the changes and [submitting your app to the Mac App store](http://electron.atom.io/docs/latest/tutorial/mac-app-store-submission-guide) in the documentation. The distributions can be found on the [Electron releases page](https://github.com/electron/electron/releases), prefixed with `mas-`.
+Additionally some behaviors have changed with respect to detecting DNS changes, video capture and accessibility features. You can read more about the changes and [submitting your app to the Mac App store](https://electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide) in the documentation. The distributions can be found on the [Electron releases page](https://github.com/electron/electron/releases), prefixed with `mas-`.
 
 Related Pull Requests: [electron/electron#3108](https://github.com/electron/electron/pull/3108), [electron/electron#2920](https://github.com/electron/electron/pull/2920)
 

--- a/data/blog/electron.md
+++ b/data/blog/electron.md
@@ -4,7 +4,7 @@ author: kevinsawicki
 date: '2015-04-23'
 ---
 
-Atom Shell is now called Electron. You can learn more about Electron and what people are building with it at its new home [electron.atom.io][electron].
+Atom Shell is now called Electron. You can learn more about Electron and what people are building with it at its new home [electronjs.org][electron].
 
 ---
 
@@ -18,7 +18,7 @@ In two years, Electron has grown immensely. It now includes automatic app update
 
 So far, individual developers, early-stage startups, and large companies have built apps on Electron. They've created a huge range of apps &mdash; including chat apps, database explorers, map designers, collaborative design tools, and mobile prototyping apps.
 
-Check out the new [electron.atom.io][electron] to see more of the apps people have built on Electron or take a look at the [docs][docs] to learn more about what else you can make.
+Check out the new [electronjs.org][electron] to see more of the apps people have built on Electron or take a look at the [docs][docs] to learn more about what else you can make.
 
 If you've already gotten started, we'd love to chat with you about the apps you're building on Electron. Email [electron@github.com](mailto:electron@github.com?Subject=Electron) to tell us more. You can also follow the new [@ElectronJS](https://twitter.com/electronjs) Twitter account to stay connected with the project.
 

--- a/data/blog/electron.md
+++ b/data/blog/electron.md
@@ -26,5 +26,5 @@ If you've already gotten started, we'd love to chat with you about the apps you'
 
 [atom]: https://atom.io
 [docs]: https://github.com/electron/electron/tree/master/docs#readme
-[electron]: http://electron.atom.io
+[electron]: https://electronjs.org
 

--- a/data/blog/jully-2016-roundup.md
+++ b/data/blog/jully-2016-roundup.md
@@ -8,7 +8,7 @@ We're starting a monthly roundup to highlight activity in the Electron community
 
 ---
 
-This site is updated with new [apps](http://electron.atom.io/apps) and [meetups](http://electron.atom.io/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](http://electron.atom.io/feed.xml).
+This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
 If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
 

--- a/data/blog/jully-2016-roundup.md
+++ b/data/blog/jully-2016-roundup.md
@@ -8,9 +8,9 @@ We're starting a monthly roundup to highlight activity in the Electron community
 
 ---
 
-This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
+This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electronjs.org/pulls) from the community. You can [watch the repository](https://github.com/electron/electronjs.org) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
-If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
+If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electronjs.org) to add it to the site and it will make the next roundup.
 
 ### New Apps
 

--- a/data/blog/july-2016-roundup.md
+++ b/data/blog/july-2016-roundup.md
@@ -8,7 +8,7 @@ We're starting a monthly roundup to highlight activity in the Electron community
 
 ---
 
-This site is updated with new [apps](http://electron.atom.io/apps) and [meetups](http://electron.atom.io/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](http://electron.atom.io/feed.xml).
+This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
 If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
 

--- a/data/blog/july-2016-roundup.md
+++ b/data/blog/july-2016-roundup.md
@@ -8,9 +8,9 @@ We're starting a monthly roundup to highlight activity in the Electron community
 
 ---
 
-This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
+This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electronjs.org/pulls) from the community. You can [watch the repository](https://github.com/electron/electronjs.org) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
-If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
+If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electronjs.org) to add it to the site and it will make the next roundup.
 
 ### New Apps
 

--- a/data/blog/kap.md
+++ b/data/blog/kap.md
@@ -83,5 +83,5 @@ The next step for us is to review the app in preparation for our 2.0.0 milestone
 
 ## Any Electron tips that might be useful to other developers?
 
-Take advantage of and get involved in the fantastic [community](https://discuss.atom.io/c/electron), check out [Awesome Electron](https://github.com/sindresorhus/awesome-electron), look at [examples](https://github.com/electron/electron-api-demos) and make use of the great [docs](http://electron.atom.io/docs/)!
+Take advantage of and get involved in the fantastic [community](https://discuss.atom.io/c/electron), check out [Awesome Electron](https://github.com/sindresorhus/awesome-electron), look at [examples](https://github.com/electron/electron-api-demos) and make use of the great [docs](https://electronjs.org/docs/)!
 

--- a/data/blog/latest-v8-chromium-features.md
+++ b/data/blog/latest-v8-chromium-features.md
@@ -8,7 +8,7 @@ Building an Electron application means you only need to create one codebase and 
 
 ---
 
-There are many features and we'll cover some here as examples, but if you're interested in learning about all features you can keep an eye on the [Google Chromium blog](http://blog.chromium.org) and [Node.js changelogs](https://nodejs.org/en/download/releases). You can see what versions of Node.js, Chromium and V8 Electron is using at [electron.atom.io/#electron-versions](https://electronjs.org/#electron-versions).
+There are many features and we'll cover some here as examples, but if you're interested in learning about all features you can keep an eye on the [Google Chromium blog](http://blog.chromium.org) and [Node.js changelogs](https://nodejs.org/en/download/releases). You can see what versions of Node.js, Chromium and V8 Electron is using at [electronjs.org/#electron-versions](https://electronjs.org/#electron-versions).
 
 ## ES6 Support through V8
 

--- a/data/blog/latest-v8-chromium-features.md
+++ b/data/blog/latest-v8-chromium-features.md
@@ -8,7 +8,7 @@ Building an Electron application means you only need to create one codebase and 
 
 ---
 
-There are many features and we'll cover some here as examples, but if you're interested in learning about all features you can keep an eye on the [Google Chromium blog](http://blog.chromium.org) and [Node.js changelogs](https://nodejs.org/en/download/releases). You can see what versions of Node.js, Chromium and V8 Electron is using at [electron.atom.io/#electron-versions](http://electron.atom.io/#electron-versions).
+There are many features and we'll cover some here as examples, but if you're interested in learning about all features you can keep an eye on the [Google Chromium blog](http://blog.chromium.org) and [Node.js changelogs](https://nodejs.org/en/download/releases). You can see what versions of Node.js, Chromium and V8 Electron is using at [electron.atom.io/#electron-versions](https://electronjs.org/#electron-versions).
 
 ## ES6 Support through V8
 
@@ -68,7 +68,7 @@ Thanks to all the hard work Google and contributors put into Chromium, when you 
 - [CSS.escape()](https://googlechrome.github.io/samples/css-escape/index.html)
 - [Fetch API Streaming](https://googlechrome.github.io/samples/fetch-api/fetch-response-stream.html)
 
-Follow along with the [Google Chromium blog](http://blog.chromium.org) to learn about features as new versions ship and again, you can check the version of Chromium that Electron uses [here](http://electron.atom.io/#electron-versions).
+Follow along with the [Google Chromium blog](http://blog.chromium.org) to learn about features as new versions ship and again, you can check the version of Chromium that Electron uses [here](https://electronjs.org/#electron-versions).
 
 ## What are you excited about?
 

--- a/data/blog/new-website.md
+++ b/data/blog/new-website.md
@@ -45,7 +45,7 @@ translating on [Crowdin], where you can sign in using your GitHub account.
 There are currently 21 languages enabled for the Electron project on Crowdin. 
 Adding support for more languages is easy, so if you're interested in 
 helping translate but you don't see your language listed, 
-[let us know](https://github.com/electron/electron.atom.io/issues/new) and
+[let us know](https://github.com/electron/electronjs.org/issues/new) and
 we'll enable it.
 
 ## Raw Translated Docs

--- a/data/blog/september-2016-roundup.md
+++ b/data/blog/september-2016-roundup.md
@@ -8,9 +8,9 @@ Here are the new Electron apps and talks that were added to the site in Septembe
 
 ---
 
-This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
+This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electronjs.org/pulls) from the community. You can [watch the repository](https://github.com/electron/electronjs.org) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
-If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
+If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electronjs.org) to add it to the site and it will make the next roundup.
 
 ### New Talks
 

--- a/data/blog/september-2016-roundup.md
+++ b/data/blog/september-2016-roundup.md
@@ -8,7 +8,7 @@ Here are the new Electron apps and talks that were added to the site in Septembe
 
 ---
 
-This site is updated with new [apps](http://electron.atom.io/apps) and [meetups](http://electron.atom.io/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](http://electron.atom.io/feed.xml).
+This site is updated with new [apps](https://electronjs.org/apps) and [meetups](https://electronjs.org/community) through [pull requests](https://github.com/electron/electron.atom.io/pulls) from the community. You can [watch the repository](https://github.com/electron/electron.atom.io) to get notifications of new additions or if you're not interested in _all_ of the site's changes, subscribe to the [blog RSS feed](https://electronjs.org/feed.xml).
 
 If you've made an Electron app or host a meetup, make a [pull request](https://github.com/electron/electron.atom.io) to add it to the site and it will make the next roundup.
 

--- a/data/blog/simple-samples.md
+++ b/data/blog/simple-samples.md
@@ -60,7 +60,6 @@ We hope these apps help you get started using Electron. Here are a handful other
 
 - [electron-quick-start](https://github.com/electron/electron-quick-start): A minimal Electron application boilerplate.
 - [Electron API Demos](https://github.com/electron/electron-api-demos): An interactive app that demonstrates the core features of the Electron API
-- [electron.atom.io/docs/all](https://electronjs.org/docs/all/): All of the Electron documentation together on a single searchable page.
+- [electronjs.org/docs/all](https://electronjs.org/docs/all/): All of the Electron documentation together on a single searchable page.
 - [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps): Another collection of sample applications for Electron, compiled by Electron maintainer [Haojian Wu](https://github.com/hokein).
 - [awesome-electron](https://github.com/sindresorhus/awesome-electron) - A GitHub repository that collects the latest and greatest Electron-related tutorials, books, videos, etc.
-

--- a/data/blog/simple-samples.md
+++ b/data/blog/simple-samples.md
@@ -60,7 +60,7 @@ We hope these apps help you get started using Electron. Here are a handful other
 
 - [electron-quick-start](https://github.com/electron/electron-quick-start): A minimal Electron application boilerplate.
 - [Electron API Demos](https://github.com/electron/electron-api-demos): An interactive app that demonstrates the core features of the Electron API
-- [electron.atom.io/docs/all](http://electron.atom.io/docs/all/): All of the Electron documentation together on a single searchable page.
+- [electron.atom.io/docs/all](https://electronjs.org/docs/all/): All of the Electron documentation together on a single searchable page.
 - [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps): Another collection of sample applications for Electron, compiled by Electron maintainer [Haojian Wu](https://github.com/hokein).
 - [awesome-electron](https://github.com/sindresorhus/awesome-electron) - A GitHub repository that collects the latest and greatest Electron-related tutorials, books, videos, etc.
 

--- a/data/blog/typescript.md
+++ b/data/blog/typescript.md
@@ -62,7 +62,7 @@ TypeScript definition file. When you install the `electron` package from npm,
 the `electron.d.ts` file is bundled automatically with the
 installed package.
 
-The [safest way](https://electron.atom.io/docs/tutorial/electron-versioning/) to install Electron is using an exact version number:
+The [safest way](https://electronjs.org/docs/tutorial/electron-versioning/) to install Electron is using an exact version number:
 
 ```sh
 npm install electron --save-dev --save-exact
@@ -79,8 +79,8 @@ and `@types/node`, you should remove them from your Electron project to prevent
 any collisions.
 
 The definition file is derived from our
-[structured API documentation](https://electron.atom.io/blog/2016/09/27/api-docs-json-schema),
-so it will always be consistent with [Electron's API documentation](https://electron.atom.io/docs/api/).
+[structured API documentation](https://electronjs.org/blog/2016/09/27/api-docs-json-schema),
+so it will always be consistent with [Electron's API documentation](https://electronjs.org/docs/api/).
 Just install `electron` and you'll always get TypeScript definitions that are
 up to date with the version of Electron you're using.
 

--- a/data/blog/userland.md
+++ b/data/blog/userland.md
@@ -80,13 +80,13 @@ new reports to the website.
 
 All of the tools used to collect and display this data are open-source:
 
-- [electron/electron.atom.io](https://github.com/electron/electron.atom): The Electron website.
+- [electron/electronjs.org](https://github.com/electron/electron.atom): The Electron website.
 - [electron/electron-userland-reports](https://github.com/electron/electron-userland-reports): Slices of data about packages, repos, and users in Electron userland.
 - [electron/repos-using-electron](https://github.com/electron/repos-using-electron): All public repositories on GitHub that depend on `electron` or `electron-prebuilt`
 - [electron/electron-npm-packages](https://github.com/zeke/electron-npm-packages): All npm packages that mention `electron` in their `package.json` file.
 
 If you have ideas about how to improve these reports, please let us know
-[opening an issue on the website repository](https://github.com/electron/electron.atom.io/issues/new)
+[opening an issue on the website repository](https://github.com/electron/electronjs.org/issues/new)
 or any of the above-mentioned repos.
 
 Thanks to you, the Electron community, for making userland what it is today!

--- a/data/blog/userland.md
+++ b/data/blog/userland.md
@@ -4,13 +4,13 @@ author: zeke
 date: '2016-12-20'
 ---
 
-We've added a new [userland](http://electron.atom.io/userland) section to
+We've added a new [userland](https://electronjs.org/userland) section to
 the Electron website to help users discover the people, packages, and apps that make
 up our flourishing open-source ecosystem.
 
 ---
 
-[![github-contributors](https://cloud.githubusercontent.com/assets/2289/21205352/a873f86c-c210-11e6-9a92-1ef37dfc986b.png)](http://electron.atom.io/userland)
+[![github-contributors](https://cloud.githubusercontent.com/assets/2289/21205352/a873f86c-c210-11e6-9a92-1ef37dfc986b.png)](https://electronjs.org/userland)
 
 ## Origins of Userland
 
@@ -49,19 +49,19 @@ counts, etc.
 
 We then used this data to generate the following reports:
 
-- [App Development Dependencies](http://electron.atom.io/userland/dev_dependencies): Packages most often listed as `devDependencies` in Electron apps.
-- [GitHub Contributors](http://electron.atom.io/userland/github_contributors): GitHub users who have contributed to numerous Electron-related GitHub repositories.
-- [Package Dependencies](http://electron.atom.io/userland/package_dependencies): Electron-related npm packages that are frequently depended on by other npm packages.
-- [Starred Apps](http://electron.atom.io/userland/starred_apps): Electron apps (that are not npm packages) with numerous stargazers.
-- [Most Downloaded Packages](http://electron.atom.io/userland/most_downloaded_packages): Electron-related npm packages that are downloaded a lot.
-- [App Dependencies](http://electron.atom.io/userland/dependencies): Packages most often listed as `dependencies` in Electron apps.
-- [Package Authors](http://electron.atom.io/userland/package_authors): The most prolific authors of Electron-related npm packages.
+- [App Development Dependencies](https://electronjs.org/userland/dev_dependencies): Packages most often listed as `devDependencies` in Electron apps.
+- [GitHub Contributors](https://electronjs.org/userland/github_contributors): GitHub users who have contributed to numerous Electron-related GitHub repositories.
+- [Package Dependencies](https://electronjs.org/userland/package_dependencies): Electron-related npm packages that are frequently depended on by other npm packages.
+- [Starred Apps](https://electronjs.org/userland/starred_apps): Electron apps (that are not npm packages) with numerous stargazers.
+- [Most Downloaded Packages](https://electronjs.org/userland/most_downloaded_packages): Electron-related npm packages that are downloaded a lot.
+- [App Dependencies](https://electronjs.org/userland/dependencies): Packages most often listed as `dependencies` in Electron apps.
+- [Package Authors](https://electronjs.org/userland/package_authors): The most prolific authors of Electron-related npm packages.
 
 ## Filtering Results
 
 Reports like
-[app dependencies](http://electron.atom.io/userland/dependencies) and
-[starred apps](http://electron.atom.io/userland/starred_apps)
+[app dependencies](https://electronjs.org/userland/dependencies) and
+[starred apps](https://electronjs.org/userland/starred_apps)
 which list packages, apps, and repos have a text input that can be used to
 filter the results.
 
@@ -70,7 +70,7 @@ allows you to copy a URL representing a particular slice of userland data,
 then share it with others.
 
 [![babel](https://cloud.githubusercontent.com/assets/2289/21328807/7bfa75e4-c5ea-11e6-8212-0e7988b367fd.png)
-](http://electron.atom.io/userland/dev_dependencies?q=babel%20preset)
+](https://electronjs.org/userland/dev_dependencies?q=babel%20preset)
 
 ## More to come
 

--- a/data/blog/voltra.md
+++ b/data/blog/voltra.md
@@ -90,5 +90,5 @@ We‘re currently developing a mobile app, and working with artists and labels t
 
 [setImmediate]: https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate
 [requestIdleCallback]: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
-[IPC]: https://electron.atom.io/docs/glossary/#ipc
+[IPC]: https://electronjs.org/docs/glossary/#ipc
 

--- a/data/blog/webtorrent.md
+++ b/data/blog/webtorrent.md
@@ -88,7 +88,7 @@ There is a meme that Electron apps are "bloated" because they include the entire
 
 However, in the case of WebTorrent Desktop, we use nearly every Electron feature, and many dozens of Chrome features in the course of normal operation. If we wanted to implement these features from scratch for each platform, it would have taken months or years longer to build our app, or we would have only been able to release for a single platform.
 
-Just to get an idea, we use Electron's [dock integration](https://electron.atom.io/docs/api/app/#appdockbouncetype-macos) (to show download progress), [menu bar integration](https://electron.atom.io/docs/api/menu/) (to run in the background), [protocol handler registration](https://electron.atom.io/docs/api/app/#appsetasdefaultprotocolclientprotocol-path-args-macos-windows) (to open magnet links), [power save blocker](https://electron.atom.io/docs/api/power-save-blocker/) (to prevent sleep during video playback), and [automatic updater](https://electron.atom.io/docs/api/auto-updater/). As for Chrome features, we use plenty: the `<video>` tag (to play many different video formats), the `<track>` tag (for closed captions support), drag-and-drop support, and WebRTC (which is non-trivial to use in a native app).
+Just to get an idea, we use Electron's [dock integration](https://electronjs.org/docs/api/app/#appdockbouncetype-macos) (to show download progress), [menu bar integration](https://electronjs.org/docs/api/menu/) (to run in the background), [protocol handler registration](https://electronjs.org/docs/api/app/#appsetasdefaultprotocolclientprotocol-path-args-macos-windows) (to open magnet links), [power save blocker](https://electronjs.org/docs/api/power-save-blocker/) (to prevent sleep during video playback), and [automatic updater](https://electronjs.org/docs/api/auto-updater/). As for Chrome features, we use plenty: the `<video>` tag (to play many different video formats), the `<track>` tag (for closed captions support), drag-and-drop support, and WebRTC (which is non-trivial to use in a native app).
 
 Not to mention: our torrent engine is written in JavaScript and assumes the existence of lots of Node APIs, but especially `require('net')` and `require('dgram')` for TCP and UDP socket support.
 
@@ -108,7 +108,7 @@ Yes, the [`webtorrent` npm package](https://npmjs.com/package/webtorrent) works 
 
 In early versions of the app, we struggled to make the UI performant. We put the torrent engine in the same renderer process that draws the main app window which, predictably, led to slowness anytime there was intense CPU activity from the torrent engine (like verifying the torrent pieces received from peers).
 
-We fixed this by moving the torrent engine to a second, invisible renderer process that we communicate with over [IPC](https://electron.atom.io/docs/api/ipc-main/). This way, if that process briefly uses a lot of CPU, the UI thread will be unaffected. Buttery-smooth scrolling and animations are so satisfying.
+We fixed this by moving the torrent engine to a second, invisible renderer process that we communicate with over [IPC](https://electronjs.org/docs/api/ipc-main/). This way, if that process briefly uses a lot of CPU, the UI thread will be unaffected. Buttery-smooth scrolling and animations are so satisfying.
 
 Note: we had to put the torrent engine in a renderer process, instead of a "main" process, because we need access to WebRTC (which is only available in the renderer.)
 

--- a/data/locale.yml
+++ b/data/locale.yml
@@ -42,7 +42,7 @@ community:
     <a href="https://github.com/sindresorhus/awesome-electron/blob/master/contributing.md">Make a pull request</a>.
   meetup_notice:
     To add a meetup, edit <code>data/meetups.json</code> and 
-    <a href="https://github.com/electron/electron.atom.io/tree/master/data/meetups.yml">make a pull request</a>.
+    <a href="https://github.com/electron/electronjs.org/tree/master/data/meetups.yml">make a pull request</a>.
 
 electron_is_easy:
   title: It's easier than you think

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "The [website](https://electronjs.org) for [Electron](https://github.com/electron/electron).",
-  "repository": "https://github.com/electron/electron.atom.io",
+  "repository": "https://github.com/electron/electronjs.org",
   "homepage": "https://electronjs.org",
   "author": "GitHub",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "electron.atom.io",
-  "version": "1.0.0",
+  "name": "electronjs.org",
+  "version": "2.0.0",
   "private": true,
   "description": "The [website](https://electronjs.org) for [Electron](https://github.com/electron/electron).",
   "repository": "https://github.com/electron/electronjs.org",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "electron.atom.io",
   "version": "1.0.0",
   "private": true,
-  "description": "The [website](http://electron.atom.io) for [Electron](https://github.com/electron/electron).",
+  "description": "The [website](https://electronjs.org) for [Electron](https://github.com/electron/electron).",
   "repository": "https://github.com/electron/electron.atom.io",
-  "homepage": "http://electron.atom.io",
+  "homepage": "https://electronjs.org",
   "author": "GitHub",
   "license": "MIT",
   "scripts": {

--- a/script/release
+++ b/script/release
@@ -6,7 +6,7 @@ set -o pipefail   # honor exit codes when piping
 set -o nounset    # fail on unset variables
 
 # clone the repo
-git clone https://github.com/electron/electron.atom.io site
+git clone https://github.com/electron/electronjs.org site
 cd site
 npm install
 

--- a/scripts/platform-specific-content.js
+++ b/scripts/platform-specific-content.js
@@ -1,8 +1,8 @@
 // Reveal hidden elements that are specific to the user's OS
-// 
+//
 // To use: apply a class of `darwin-only`, `linux-only`, or `win32-only`
 // to any element. It will be hidden by default, and revealed on page load.
-// 
+//
 // Elements will be displayed as `block` by default. To use another display
 // value, add a class to the element like `display-inline-block` or
 // `display-table-row`

--- a/server.js
+++ b/server.js
@@ -66,8 +66,8 @@ app.get('/docs', routes.docs.index)
 app.get('/docs/:category', routes.docs.category)
 app.get('/docs/:category/*', routes.docs.show)
 
-app.get('/issues', (req, res) => res.redirect(301, 'https://github.com/electron/electron.atom.io/issues'))
-app.get('/issues/new', (req, res) => res.redirect(301, 'https://github.com/electron/electron.atom.io/issues/new'))
+app.get('/issues', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/issues'))
+app.get('/issues/new', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/issues/new'))
 
 app.get('/userland', routes.userland.index)
 app.get('/userland/*', routes.userland.show)

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ async function get (route) {
   return $
 }
 
-describe('electron.atom.io', () => {
+describe('electronjs.org', () => {
   describe('homepage', () => {
     test('displays featured apps, version numbers, and CoC link', async () => {
       const $ = await get('/')

--- a/test/index.js
+++ b/test/index.js
@@ -210,13 +210,13 @@ describe('electron.atom.io', () => {
     test('redirects /issues to the website repo, for convenience', async () => {
       const res = await supertest(app).get('/issues')
       res.statusCode.should.equal(301)
-      res.headers.location.should.equal('https://github.com/electron/electron.atom.io/issues')
+      res.headers.location.should.equal('https://github.com/electron/electronjs.org/issues')
     })
 
     test('redirects /issues/new to the website repo, for convenience', async () => {
       const res = await supertest(app).get('/issues')
       res.statusCode.should.equal(301)
-      res.headers.location.should.equal('https://github.com/electron/electron.atom.io/issues')
+      res.headers.location.should.equal('https://github.com/electron/electronjs.org/issues')
     })
   })
 })

--- a/views/404.html
+++ b/views/404.html
@@ -9,7 +9,7 @@
       {{/if}}
 
       {{localized._404.if_this_is_an_error}}
-      <a href="https://github.com/electron/electron.atom.io/issues/new?title=404%20for%20{{page.path}}&body=The%20following%20route%20is%20returning%20a%20404%20HTTP%20status%20code%3A%20{{page.path}}">{{localized._404.please_file_an_issue}}</a>.
+      <a href="https://github.com/electron/electronjs.org/issues/new?title=404%20for%20{{page.path}}&body=The%20following%20route%20is%20returning%20a%20404%20HTTP%20status%20code%3A%20{{page.path}}">{{localized._404.please_file_an_issue}}</a>.
     </p>
   </div>
 </section>

--- a/views/home.html
+++ b/views/home.html
@@ -170,7 +170,7 @@ $ npm install &amp;&amp; npm start</code></pre>
       <p class="mt-6">
         <a href='/apps'>{{{localized.apps.view_more}}}</a>
           {{{localized.or}}}
-          <a href="https://github.com/electron/electron.atom.io/blob/gh-pages/CONTRIBUTING.md#adding-an-app-or-project-to-the-site">{{{localized.apps.submit_your_own}}}</a>.
+          <a href="https://github.com/electron/electronjs.org/blob/gh-pages/CONTRIBUTING.md#adding-an-app-or-project-to-the-site">{{{localized.apps.submit_your_own}}}</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This PR updates a bunch of references to the old domain.

cc @codebytere 