### PR TITLE
Test locale strings

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -61,7 +61,7 @@ web_technologies:
 
 open_source:
   title: Open Source
-  desciption:
+  description:
     Electron is an open source project maintained by GitHub and an active
     community of contributors.
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "nodemon": "^1.11.0",
     "npm-run-all": "^4.1.2",
     "standard": "^10.0.3",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "walk-sync": "^0.3.2"
   },
   "engines": {
     "node": "8"

--- a/test/localization.js
+++ b/test/localization.js
@@ -1,0 +1,57 @@
+require('require-yaml')
+
+const {describe, it} = require('mocha')
+const chai = require('chai')
+chai.should()
+const {expect} = chai
+const fs = require('fs')
+const path = require('path')
+const walk = require('walk-sync')
+const flat = require('flat')
+const getProp = require('lodash').get
+
+const locale = require(path.join(__dirname, '../data/locale.yml'))
+const views = walk.entries(path.join(__dirname, '../views'))
+  .filter(entry => path.extname(entry.relativePath) === '.html')
+  .map(entry => {
+    const fullPath = path.join(entry.basePath, entry.relativePath)
+    const view = {
+      relativePath: entry.relativePath,
+      localizedKeys: (fs.readFileSync(fullPath, 'utf8').match(/{{[\./]*localized\.[a-z_\.]*}}/g) || [])
+        .map(ref => ref.replace(/\.\.\//g, '').replace('{{localized.', '').replace('}}', ''))  
+    }
+    return view
+  })
+  .filter(view => view.localizedKeys.length)
+  // console.log(views)
+
+describe('localized views', () => {
+  // Find all instances of {{localized.something.something}} in the views
+  // and ensure that locale.yml has a corresponding string
+  it('every reference to a localized string is defined', () => {
+    views.should.be.an('array')
+    views.length.should.be.above(8)
+    views.forEach(view => {
+      view.localizedKeys.length.should.be.above(0)
+      view.localizedKeys.forEach(key => {
+        expect(getProp(locale, key), `${view.relativePath}: ${key} has no string in locale.yml`).to.be.a('string')
+      })
+    })
+  })
+
+  // Ensure every string in locale.yml is actually used somewhere
+  it('every localized string is used in a view (except for pages.* and _404.*)', () => {
+    const keys = Object.keys(flat(locale))
+      .filter(key => !key.startsWith('pages.'))
+      .filter(key => !key.startsWith('_404.'))
+    keys.should.be.an('array')
+    keys.length.should.be.above(50)
+    
+    const usedKeys = views.reduce((acc, view) => {
+      acc = acc.concat(view.localizedKeys)
+      return acc
+    }, [])
+    
+    keys.forEach(key => expect(usedKeys).to.include(key))
+  })
+})

--- a/test/localization.js
+++ b/test/localization.js
@@ -17,8 +17,8 @@ const views = walk.entries(path.join(__dirname, '../views'))
     const fullPath = path.join(entry.basePath, entry.relativePath)
     const view = {
       relativePath: entry.relativePath,
-      localizedKeys: (fs.readFileSync(fullPath, 'utf8').match(/{{[\./]*localized\.[a-z_\.]*}}/g) || [])
-        .map(ref => ref.replace(/\.\.\//g, '').replace('{{localized.', '').replace('}}', ''))  
+      localizedKeys: (fs.readFileSync(fullPath, 'utf8').match(/{{[./]*localized\.[a-z_.]*}}/g) || [])
+        .map(ref => ref.replace(/\.\.\//g, '').replace('{{localized.', '').replace('}}', ''))
     }
     return view
   })
@@ -46,12 +46,12 @@ describe('localized views', () => {
       .filter(key => !key.startsWith('_404.'))
     keys.should.be.an('array')
     keys.length.should.be.above(50)
-    
+
     const usedKeys = views.reduce((acc, view) => {
       acc = acc.concat(view.localizedKeys)
       return acc
     }, [])
-    
+
     keys.forEach(key => expect(usedKeys).to.include(key))
   })
 })

--- a/views/home.html
+++ b/views/home.html
@@ -51,7 +51,7 @@
     </div>
 
     <div class="row text-center mt-6 mb-4">
-      <h2>{{{localized.hard_parts_made_easy}}}</h2>
+      <h2>{{{localized.benefits.hard_parts_made_easy}}}</h2>
     </div>
 
     <div class="row text-center text-small mt-3">


### PR DESCRIPTION
This PR adds some test to verify that all references like `{{localized.foo.bar}}` are defined in `data/locale.yml`, and conversely that all strings defined in the locale file are used by the views.

cc @vanessayuenn 