### PR TITLE
convenience url for pull requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -68,6 +68,7 @@ app.get('/docs/:category/*', routes.docs.show)
 
 app.get('/issues', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/issues'))
 app.get('/issues/new', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/issues/new'))
+app.get('/pulls', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/pulls'))
 
 app.get('/userland', routes.userland.index)
 app.get('/userland/*', routes.userland.show)

--- a/test/index.js
+++ b/test/index.js
@@ -208,7 +208,7 @@ describe('electronjs.org', () => {
     res.headers.location.should.equal('/apps')
   })
 
-  describe('issues', () => {
+  describe('issues and pull request URLs', () => {
     test('redirects /issues to the website repo, for convenience', async () => {
       const res = await supertest(app).get('/issues')
       res.statusCode.should.equal(301)
@@ -219,6 +219,12 @@ describe('electronjs.org', () => {
       const res = await supertest(app).get('/issues')
       res.statusCode.should.equal(301)
       res.headers.location.should.equal('https://github.com/electron/electronjs.org/issues')
+    })
+
+    test('redirects /pulls to the website repo, for convenience', async () => {
+      const res = await supertest(app).get('/pulls')
+      res.statusCode.should.equal(301)
+      res.headers.location.should.equal('https://github.com/electron/electronjs.org/pulls')
     })
   })
 })


### PR DESCRIPTION
Visit https://electronjs.org/pulls and you'll be redirected to https://github.com/electron/electronjs.org/pulls.