### PR TITLE
[SEO] Add missing metadata for documentation pages

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -157,6 +157,15 @@ pages:
   '/docs/all':
     title: All the Electron Docs!
     description: All of Electron's guides and API documentation on a single, searchable page.
+  '/docs/api':
+    title: API
+    description: API reference documentation for the latest Electron release
+  '/docs/development':
+    title: Development
+    description: Developing with Electron
+  '/docs/tutorial':
+    title: Tutorial
+    description: Guides and tutorials for the latest Electron release
   '/blog':
     title: Electron Blog
     description: All the latest news from the Electron team and community.


### PR DESCRIPTION
I noticed that some of the documentation pages for electronjs.org were missing some metadata and showing `undefined` in tabs. I've added to `data/locale.yaml` to fix it

Before:
<img width="209" alt="before" src="https://user-images.githubusercontent.com/3483106/32970122-7ddf0038-cb9c-11e7-8e72-b50b496ec42e.png">
```
<meta property="og:type" content="website" />
<title>undefined | Electron</title>
<meta property="og:title" content="undefined | Electron" />
<meta name="twitter:title" value="undefined | Electron" />
<meta name="twitter:card" content="summary">
<meta name="twitter:site" content="@ElectronJS" />

```

After:
<img width="699" alt="after" src="https://user-images.githubusercontent.com/3483106/32970121-7dc25578-cb9c-11e7-885d-7873b7fc3a37.png">
```
<meta property="og:type" content="website" />
<title>Tutorial | Electron</title>
<meta property="og:title" content="Tutorial | Electron" />
<meta name="twitter:title" value="Tutorial | Electron" />
<meta property="og:description" content="Guides and tutorials for the latest Electron release" />
<meta name="twitter:description" value="Guides and tutorials for the latest Electron release" />
<meta name="twitter:card" content="summary">
<meta name="twitter:site" content="@ElectronJS" />
```

---
I chose some placeholder text for these but feel free to change them however you like.