### PR TITLE
Don't auto execute shell one liners

### DIFF
--- a/views/apps/show.html
+++ b/views/apps/show.html
@@ -32,6 +32,16 @@
     color: {{app.goodColorOnWhite}};
   }
 
+  .shell-one-liner::after {
+    content: '';
+    display: inline-block;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -o-user-select: none;
+    -ms-user-select: none;
+  }
+
 </style>
 
 <section class="page-section">


### PR DESCRIPTION
Currently if you copy paste a one liner from the site into terminal it will copy a newline char as well, this will cause the one liner to automatically execute.  My terminal won't auto exec but it does throw warnings my way whenever it prevents something auto executing (how I noticed this) 😄 