### PR TITLE
gzip-encode response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1392,6 +1392,11 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
     "cacheable-request": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.1.tgz",
@@ -1801,6 +1806,64 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "compressible": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+      "requires": {
+        "mime-db": "1.31.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.31.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.31.0.tgz",
+          "integrity": "sha512-oB3w9lx50CMd6nfonoV5rBRUbJtjMifUHaFb5MfzjC8ksAIfVjT0BsX46SjjqBz7n9JGTrTX3paIeLSK+rS5fQ=="
+        }
+      }
+    },
+    "compression": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+      "requires": {
+        "accepts": "1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "2.0.12",
+        "debug": "2.6.9",
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+          "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+          "requires": {
+            "mime-types": "2.1.16",
+            "negotiator": "0.6.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "vary": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2463,9 +2526,9 @@
       "integrity": "sha512-wuUvlAndv0pTduvrkco73v3G+N3CyFQr6tUZX+6gYOzCRvAufq2atCmoUonr0wOWFviVgc9DFEQ3+c7FS+YRZw=="
     },
     "electron-i18n": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-0.12.0.tgz",
-      "integrity": "sha512-BR17QzBaxckVyvXEzXdhIb9zMVD7wcjURf3iDqW6/k/YUeVUcPqr3Xd5RutrXZgfCnOjPMuurhmWwjsrOTg/mw=="
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-0.15.0.tgz",
+      "integrity": "sha512-J2iBVTZ+ZbNexBFowV3gCwPAwoM5JCeswNhDK7aOtDzvngayE3r8cqaSOc1+OIXZzeUexTnOAvvZtCr6CFjWRA=="
     },
     "electron-to-chromium": {
       "version": "1.3.26",
@@ -6725,6 +6788,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "browser-date-formatter": "^2.1.1",
     "browser-sync": "^2.18.12",
     "browserify-middleware": "^8.0.0",
+    "compression": "^1.7.1",
     "connect-browser-sync": "^2.1.0",
     "connect-slashes": "^1.3.1",
     "cookie-parser": "^1.4.3",

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const lobars = require('lobars')
 
 // Middleware
 const hbs = require('express-hbs')
+const compression = require('compression')
 const slashes = require('connect-slashes')
 const browsersync = require('./middleware/browsersync')
 const browserify = require('./middleware/browserify')
@@ -36,6 +37,7 @@ app.engine('html', hbs.express4({
 // Middleware
 app.set('view engine', 'html')
 app.set('views', path.join(__dirname, '/views'))
+app.use(compression())
 app.use(helmet())
 app.use(sass())
 app.use('/scripts/index.js', browserify('scripts/index.js'))

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,11 @@ async function get (route) {
 }
 
 describe('electronjs.org', () => {
+  test('gzip enabled', async () => {
+    const res = await supertest(app).get(`/`)
+    res.headers['content-encoding'].should.equal('gzip')
+  })
+
   describe('homepage', () => {
     test('displays featured apps, version numbers, and CoC link', async () => {
       const $ = await get('/')


### PR DESCRIPTION
I tried running lighthouse against the website, and it recommends gzipping the responses

![image](https://user-images.githubusercontent.com/538488/33104279-1822e2c6-cedc-11e7-8426-795313726ced.png)

Implemented something, as recommended by [express](https://expressjs.com/en/advanced/best-practice-performance.html#use-gzip-compression). Alternatively they recommend using a reverse proxy.