### PR TITLE
pin electron-apps version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "connect-slashes": "^1.3.1",
     "cookie-parser": "^1.4.3",
     "dotenv": "^4.0.0",
-    "electron-apps": "^1.1903.0",
+    "electron-apps": "1.1965.0",
     "electron-i18n": "^0.16.0",
     "electron-userland-reports": "1.6.0",
     "express": "^4.15.3",


### PR DESCRIPTION
Locking the version string will cause @greenkeeper to open PRs for each new version of `electron-apps`

See https://github.com/greenkeeperio/greenkeeper/issues/554#issuecomment-346984561