### PR TITLE
proxy crowdin stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "cheerio": "^1.0.0-rc.1",
     "husky": "^0.14.3",
     "mocha": "^4.0.1",
+    "nock": "^9.1.3",
     "nodemon": "^1.12.1",
     "npm-run-all": "^4.1.2",
     "standard": "^10.0.3",

--- a/routes/languages/stats.js
+++ b/routes/languages/stats.js
@@ -2,12 +2,12 @@ const got = require('got')
 
 module.exports = async (req, res) => {
   if (!process.env.CROWDIN_KEY) {
-    return res.json('process.env.CROWDIN_KEY is not set')
+    return res.status(401).json('process.env.CROWDIN_KEY is not set')
   }
 
   const url = `https://api.crowdin.com/api/project/electron/status?key=${process.env.CROWDIN_KEY}&json=true`
   try {
-    const data = await(got(url, {json: true}))
+    const data = await (got(url, {json: true}))
     res.json(data.body)
   } catch (err) {
     console.error(err)

--- a/routes/languages/status.js
+++ b/routes/languages/status.js
@@ -1,0 +1,16 @@
+const got = require('got')
+
+module.exports = async (req, res) => {
+  if (!process.env.CROWDIN_KEY) {
+    return res.json('process.env.CROWDIN_KEY is not set')
+  }
+
+  const url = `https://api.crowdin.com/api/project/electron/status?key=${process.env.CROWDIN_KEY}&json=true`
+  try {
+    const data = await(got(url, {json: true}))
+    res.json(data.body)
+  } catch (err) {
+    console.error(err)
+    return res.json('Failed to fetch Crowdin stats')
+  }
+}

--- a/server.js
+++ b/server.js
@@ -79,7 +79,7 @@ app.get('/maintainers/join', (req, res) => res.redirect('https://goo.gl/FJmZZm')
 app.get('/awesome', (req, res) => res.redirect('/community'))
 app.get('/community', routes.community)
 app.get('/languages', routes.languages.index)
-app.get('/language-stats.json', routes.languages.status)
+app.get('/language-stats.json', routes.languages.stats)
 app.get('/contact', routes.contact)
 app.get('/releases', routes.releases)
 

--- a/server.js
+++ b/server.js
@@ -79,6 +79,7 @@ app.get('/maintainers/join', (req, res) => res.redirect('https://goo.gl/FJmZZm')
 app.get('/awesome', (req, res) => res.redirect('/community'))
 app.get('/community', routes.community)
 app.get('/languages', routes.languages.index)
+app.get('/language-stats.json', routes.languages.status)
 app.get('/contact', routes.contact)
 app.get('/releases', routes.releases)
 


### PR DESCRIPTION
This PR will allow us to store our Crowdin API Key safely in Heroku's env, so contributors to electron-i18n will be able to fetch stats data as part of its build process, without needing to know any secrets.