### PR TITLE
test for title on homepage

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,7 @@ describe('electronjs.org', () => {
       $('header').should.have.class('site-header')
       $('p.jumbotron-lead').should.contain('Build cross platform desktop apps')
       $('.featured-app').length.should.equal(24)
+      $('head > title').text().should.match(/^Electron/)
 
       // versions
       $('#electron-versions').text().should.match(/Electron: \d+\.\d+\.\d+/)


### PR DESCRIPTION
https://twitter.com/stevesy_mke/status/935521200217968640

Not actually sure how this was happening, as we already have a test that checks the title on the /apps page. In any case a re-deploy solved it and this extra test will hopefully give us a little more protection for further regressions.