### PR TITLE
Fix missing texts at 404 pages with path: /blog/*

### DIFF
--- a/middleware/blog.js
+++ b/middleware/blog.js
@@ -43,7 +43,7 @@ module.exports = function blogHandler (req, res, next) {
 
   context.post = posts.find(post => post.href === req.path)
 
-  if (!context.post) return res.status(404).render('404')
+  if (!context.post) return next()
 
   res.render('posts/show', Object.assign(context, {
     layout: 'post',


### PR DESCRIPTION
https://electronjs.org/blog/a
![capture12](https://user-images.githubusercontent.com/12815768/33454146-84781cb4-d64a-11e7-807f-1d93f6481ec1.PNG)
