### PR TITLE
[WIP] search for misspelled apps

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -141,6 +141,8 @@ apps:
   submit_your_own: submit your own
   something_missing: Something missing?
   edit_this_app: Edit this app.
+  search:
+    no_results: "Sorry, no apps found that matched your query: "
 
 clipboard:
   copy: Copy

--- a/routes/apps/show.js
+++ b/routes/apps/show.js
@@ -5,7 +5,9 @@ const {getPlatformFromFilename} = require('platform-utils')
 module.exports = (req, res, next) => {
   const app = apps.find(app => app.slug === req.params.slug)
 
-  if (!app) return next()
+  if (!app) {
+    return res.redirect(`/apps?q=${req.params.slug}`)
+  }
 
   if (app.category) {
     app.categorySlug = categories.find(category => category.name === app.category).slug

--- a/scripts/create-filter-list.js
+++ b/scripts/create-filter-list.js
@@ -6,6 +6,7 @@ const lazyLoadImages = require('./lazy-load-images')
 module.exports = function createFilterList () {
   // look for a filterable list on this page
   const list = document.querySelector('.filterable-list')
+  const noResultsElement = document.querySelector('.no-results')
   if (!list || !list.parentElement) return
 
   // inherit initial query from `q` query param
@@ -28,7 +29,13 @@ module.exports = function createFilterList () {
   filterList.search(filterInput.value)
 
   // update the query param every time a search is performed
-  filterList.on('updated', function () {
+  filterList.on('updated', function (result) {
+    if (result && result.visibleItems && !result.visibleItems.length) {
+      noResultsElement.style.display = 'block'
+    } else {
+      noResultsElement.style.display = 'none'
+    }
+
     setQueryString({q: filterInput.value})
     list.querySelectorAll('img[data-src]').forEach(lazyLoadImages.addImage)
   })

--- a/views/apps/index.html
+++ b/views/apps/index.html
@@ -29,6 +29,8 @@
   <div class='col-xs-9 container-narrow text-center' id="apps">
     <input class="inline-filter filterable-list-input" placeholder="Filter apps by name, description, etc..." type="search" autofocus="on" tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
 
+    <p class="no-results" style="display:none">{{localized.apps.search.no_results}}</p>
+
     <ul class="mb-4 filterable-list app-list">
       {{#each apps}}
         {{#unless this.disabled}}


### PR DESCRIPTION
When `/apps/foo` is not found, redirect to a search for `foo`

This PR also updates the apps page to display a message when no results are found for the given query.