### PR TITLE
fix blog bylines

### DIFF
--- a/data/blog/beaker-browser.md
+++ b/data/blog/beaker-browser.md
@@ -1,6 +1,8 @@
 ---
 title: 'Project of the Week: Beaker Browser'
-author: zeke
+author: 
+  - pfrazee
+  - zeke
 date: '2017-02-07'
 ---
 

--- a/data/blog/dat.md
+++ b/data/blog/dat.md
@@ -1,6 +1,10 @@
 ---
 title: 'Project of the Week: Dat'
-author: zeke
+author: 
+  - karissa
+  - yoshuawuyts
+  - maxogden
+  - zeke
 date: '2017-02-21'
 ---
 

--- a/data/blog/ghost.md
+++ b/data/blog/ghost.md
@@ -1,6 +1,8 @@
 ---
 title: 'Project of the Week: Ghost'
-author: zeke
+author: 
+  - felixrieseberg
+  - zeke
 date: '2017-02-14'
 ---
 

--- a/data/blog/jasper.md
+++ b/data/blog/jasper.md
@@ -1,6 +1,9 @@
 ---
 title: 'Project of the Week: Jasper'
-author: zeke
+author: 
+  - h13i32maru
+  - watilde
+  - zeke
 date: '2017-03-21'
 ---
 

--- a/data/blog/kap.md
+++ b/data/blog/kap.md
@@ -1,6 +1,9 @@
 ---
 title: 'Project of the Week: Kap'
-author: zeke
+author: 
+  - skllcrn
+  - sindresorhus
+  - zeke
 date: '2017-01-31'
 ---
 

--- a/data/blog/voltra.md
+++ b/data/blog/voltra.md
@@ -1,9 +1,9 @@
 ---
 title: 'Project of the Week: Voltra'
 author: 
-  - zeke
   - '0x00A'
   - aprileelcich
+  - zeke
 date: '2017-03-07'
 ---
 

--- a/data/blog/voltra.md
+++ b/data/blog/voltra.md
@@ -1,6 +1,9 @@
 ---
 title: 'Project of the Week: Voltra'
-author: zeke
+author: 
+  - zeke
+  - '0x00A'
+  - aprileelcich
 date: '2017-03-07'
 ---
 

--- a/data/blog/webtorrent.md
+++ b/data/blog/webtorrent.md
@@ -1,6 +1,8 @@
 ---
 title: 'Project of the Week: WebTorrent'
-author: zeke
+author: 
+  - feross
+  - zeke
 date: '2017-03-14'
 ---
 

--- a/data/blog/wordpress.md
+++ b/data/blog/wordpress.md
@@ -1,6 +1,9 @@
 ---
 title: 'Project of the Week: WordPress Desktop'
-author: zeke
+author: 
+  - mkaz
+  - johngodley
+  - zeke
 date: '2017-02-28'
 ---
 

--- a/styles/_blog.scss
+++ b/styles/_blog.scss
@@ -16,7 +16,7 @@
   }
 }
 
-.who-when {
+.blog-byline {
   color: $main-color-subtle;
   font-size: $body-font-size;
 }

--- a/views/partials/blog_byline.html
+++ b/views/partials/blog_byline.html
@@ -1,0 +1,9 @@
+<div class="blog-byline mt-2 mb-4">
+  <span data-date="{{post.date}}" data-format="%B %d, %Y" class="blog-index-time"></span>
+
+  {{#each post.author}}
+    <a href="https://github.com/{{this.name}}" class="author-link ml-3">
+      <img src="https://github.com/{{this.name}}.png?size=36" alt="{{this.name}}" class="avatar mr-2">{{this.name}}
+    </a>
+  {{/each}}
+</div>

--- a/views/posts/index.html
+++ b/views/posts/index.html
@@ -16,13 +16,8 @@
               <a href="{{this.href}}" class="blog-index-link mr-2">
                 {{{this.title}}}
               </a>
-              <div class="who-when mt-1 mb-4">
-                <span class="octicon octicon-calendar pr-2"></span>
-                <span data-date="{{this.date}}" data-format="%B %d, %Y" class="blog-index-time"></span>
-                <a href="https://github.com/{{this.author}}" class="author-link ml-3">
-                  <img src="https://github.com/{{this.author}}.png?size=36" alt="{{this.author}}" class="avatar mr-2">{{this.author}}
-                </a>
-              </div>
+
+              {{> blog_byline post=this}}
             </h2>
             {{{this.excerpt}}}
             <p><a href="{{this.href}}">Read More&nbsp;<span class="octicon octicon-arrow-small-right"></span></a></p>

--- a/views/posts/show.html
+++ b/views/posts/show.html
@@ -1,11 +1,5 @@
 <h1>{{{post.title}}}</h1>
 
-<div class="who-when mt-1 mb-4">
-  <span class="octicon octicon-calendar pr-2"></span>
-  <span data-date="{{post.date}}" data-format="%B %d, %Y" class="blog-index-time"></span>
-  <a href="https://github.com/{{post.author}}" class="author-link ml-3">
-    <img src="https://github.com/{{post.author}}.png?size=36" alt="{{post.author}}" class="avatar mr-2">{{post.author}}
-  </a>
-</div>
+{{> blog_byline}}
 
 {{{post.content}}}


### PR DESCRIPTION
Fixes #955 
Fixes #707 

This PR updates the blog index and blog pages to display all authors for a post, preserving the singular name `author` for compatibility with the [feed](https://ghub.io/feed) module.

## Index Page

<img width="806" alt="screen shot 2017-12-14 at 9 22 50 am" src="https://user-images.githubusercontent.com/2289/34005737-c2c9da46-e0b0-11e7-8b35-49468759d9f8.png">

## Blog Pages

<img width="487" alt="screen shot 2017-12-14 at 9 22 30 am" src="https://user-images.githubusercontent.com/2289/34005748-c9e43cea-e0b0-11e7-93bc-7c2ad899c832.png">

cc @pierreneter 