### PR TITLE
Support a new `language` query param

### DIFF
--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -11,7 +11,7 @@ module.exports = function contextBuilder (req, res, next) {
   // This allows the language to be set per-request using a query param, so
   // folks can share a link like /docs/api/app?language=fr-FR and know that
   // the recipient will see the doc in that language, regardless of their
-  // language settings. If no query param is set, fall back to the default 
+  // language settings. If no query param is set, fall back to the default
   // language (or the one set in the cookie)
   const targetLanguage = req.query.language || req.language
 

--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -8,13 +8,20 @@ module.exports = function contextBuilder (req, res, next) {
   // Attach i18n object to request so any route handler can use it if needed
   req.i18n = i18n
 
-  const localized = i18n.website[req.language]
+  // This allows the language to be set per-request using a query param, so
+  // folks can share a link like /docs/api/app?language=fr-FR and know that
+  // the recipient will see the doc in that language, regardless of their
+  // language settings. If no query param is set, fall back to the default 
+  // language (or the one set in the cookie)
+  const targetLanguage = req.query.language || req.language
+
+  const localized = i18n.website[targetLanguage]
 
   // Page titles, descriptions, etc
   let page = Object.assign({
     title: 'Electron',
     path: req.path
-  }, i18n.website[req.language].pages[req.path])
+  }, i18n.website[targetLanguage].pages[req.path])
 
   if (req.path !== '/') {
     page.title = `${page.title} | Electron`
@@ -34,7 +41,7 @@ module.exports = function contextBuilder (req, res, next) {
   }
 
   if (req.path.startsWith('/docs')) {
-    req.context.docs = i18n.docs[req.language]
+    req.context.docs = i18n.docs[targetLanguage]
   }
 
   return next()

--- a/test/index.js
+++ b/test/index.js
@@ -267,10 +267,12 @@ describe('electronjs.org', () => {
     })
   })
 
-  test('/languages', async () => {
-    const $ = await get('/languages')
-    $('h1').text().should.eq('Languages')
-    $('body').text().should.include('global developer community')
+  describe('languages', () => {
+    test('/languages', async () => {
+      const $ = await get('/languages')
+      $('h1').text().should.eq('Languages')
+      $('body').text().should.include('global developer community')
+    })
   })
 
   test('redirects for date-style blog URLs', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -273,6 +273,14 @@ describe('electronjs.org', () => {
       $('h1').text().should.eq('Languages')
       $('body').text().should.include('global developer community')
     })
+
+    test('language query param for one-off viewing in other languages', async () => {
+      let $ = await get('/docs/api/browser-window')
+      $('body').text().should.not.include('fenêtres')
+
+      $ = await get('/docs/api/browser-window?language=fr-FR')
+      $('body').text().should.include('fenêtres')
+    })
   })
 
   test('redirects for date-style blog URLs', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -275,11 +275,11 @@ describe('electronjs.org', () => {
     })
 
     test('language query param for one-off viewing in other languages', async () => {
-      let $ = await get('/docs/api/browser-window')
-      $('body').text().should.not.include('fenêtres')
-
-      $ = await get('/docs/api/browser-window?language=fr-FR')
+      let $ = await get('/docs/api/browser-window?language=fr-FR')
       $('body').text().should.include('fenêtres')
+
+      $ = await get('/docs/api/browser-window')
+      $('body').text().should.not.include('fenêtres')
     })
   })
 


### PR DESCRIPTION
This PR allows a `?language=` query param to be added to any URL to view that URL in the target language. This does not have an effect on the visitor's language settings (or lack thereof). In other words, if my language is English and I view `/docs/api/app?language=fr-FR`, I will only see that one page in French. If I click any links or remove the query param from the URL, content will still be displayed in English.