### PR TITLE
excerptize protocol handler post intro

### DIFF
--- a/data/blog/protocol-handler-fix.md
+++ b/data/blog/protocol-handler-fix.md
@@ -8,6 +8,8 @@ A remote code execution vulnerability has been discovered affecting
 Electron apps that use custom protocol handlers. This vulnerability has been 
 assigned the CVE identifier [CVE-2018-1000006].
 
+---
+
 ## Affected Platforms
 
 Electron apps designed to run on Windows that register themselves as the default 


### PR DESCRIPTION
This is a cosmetic change that adds an `---` (HR tag) to prevent this entire post from being displayed on the blog index.