### PR TITLE
Upgrade primer breadcrumbs

### DIFF
--- a/middleware/sass.js
+++ b/middleware/sass.js
@@ -6,6 +6,7 @@ module.exports = function () {
     src: path.join(__dirname, '../styles'),
     response: true,
     debug: true,
+    includePaths: path.join(__dirname, '../node_modules'),
     // outputStyle: 'compressed',
     prefix: '/styles'
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -7863,17 +7863,17 @@
       "integrity": "sha1-y+NiRxPP9IAfSqBTGsP58iTTOqU="
     },
     "primer-breadcrumb": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/primer-breadcrumb/-/primer-breadcrumb-1.5.0.tgz",
-      "integrity": "sha1-z+eMQpHwUDHX87fa2SFi6FcW12w=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/primer-breadcrumb/-/primer-breadcrumb-1.5.1.tgz",
+      "integrity": "sha1-mHQDUkRetb6rtIpRqB8IOJsd79A=",
       "requires": {
-        "primer-support": "4.5.1"
+        "primer-support": "4.5.2"
       }
     },
     "primer-support": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.1.tgz",
-      "integrity": "sha1-MnOm79A2ugBTlEfWm6ZpvosR32Y="
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.5.2.tgz",
+      "integrity": "sha1-2quaSIgbaVPo5soBhlovQVv3d8U="
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node-sass-middleware": "^0.11.0",
     "parse-link-header": "^1.0.1",
     "platform-utils": "^1.0.0",
-    "primer-breadcrumb": "1.5.0",
+    "primer-breadcrumb": "1.5.1",
     "proxyquire": "^1.8.0",
     "query-string": "^5.0.0",
     "repos-using-electron": "github:electron/repos-using-electron",

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -49,7 +49,7 @@ $octicons-font-path: "../bower_components/octicons/octicons/";
 @import "../bower_components/basecoat/scss/page-headers";
 @import "../bower_components/basecoat/scss/section";
 @import "../bower_components/basecoat/scss/tables";
-@import "../node_modules/primer-breadcrumb/lib/breadcrumb";
+@import "primer-breadcrumb/index.scss";
 
 // Devicon
 @import "vendor/devicon/devicon.css";


### PR DESCRIPTION
There were a few things I noticed and fixed.

When upgrading `primer-breadcrumbs` before. The build was failing because you were importing `primer-breadcrumbs/lib/breadcrumbs.scss` directly. Importing `primer-breadcrumbs/index.scss` is recommended because it includes the required `primer-support` file.

When changing that, the sass middleware didn't know where to find it. So adding `node_modules` to the `includePaths` for the sass middleware tells it where to look when `@import "primer-support/index.scss"` is in the css.

Adding the `includePaths` removed the need to have `@import "../node_modules/primer-breadcrumbs/...` in the `styles/index.scs` file. So I updated that also.

The rest of the `primer-css` modules are so out of date, I would recommend updating them in the same way. I could easily do that in this pr, but there are potential visual breaking that could occur on the site which would take more time to debug. I would recommend starting by replacing any bower modules with node modules that haven't changed much from what you have.

closes https://github.com/primer/primer/issues/441

cc @zeke @broccolini @vanessayuenn 