### PR TITLE
test that the stylesheet responds with 200

### DIFF
--- a/bower_components/basecoat/scss/_variables.scss
+++ b/bower_components/basecoat/scss/_variables.scss
@@ -20,6 +20,19 @@ $grid-breakpoints: (
   xl: 1200px
 ) !default;
 
+// HACK! $grid-breakpoints and $breakpoints are dupes. See https://git.io/vNPI4
+$breakpoints: (
+  // Extra small screen / phone
+  xs: 0,
+  // Small screen / phone
+  sm: 544px,
+  // Medium screen / tablet
+  md: 768px,
+  // Large screen / desktop
+  lg: 992px,
+  // Extra large screen / wide desktop
+  xl: 1200px
+) !default;
 
 // Grid containers
 //

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,13 @@ describe('electronjs.org', () => {
     })
   })
 
+  describe('stylesheets', () => {
+    test('main stylesheet compiles', async () => {
+      const res = await supertest(app).get('/styles/index.css')
+      res.statusCode.should.eq(200)
+    })
+  })
+
   describe('homepage', () => {
     test('displays featured apps, version numbers, and CoC link', async () => {
       const $ = await get('/')


### PR DESCRIPTION
This is a followup to #1043 that adds a test to verify that `/styles/index.css` responds with a 200 HTTP status code. This should help prevent us from shipping stylesheet regressions in the future.


@jonrohan I see this warning show up several times in the test output:

```
WARNING: Unfortunately, no value could be retrieved from `xs`. Please make sure it is defined in `$breakpoints` map.
Backtrace:
	node_modules/primer-support/lib/mixins/layout.scss:17, in mixin `breakpoint`
	bower_components/basecoat/scss/_utility.scss:27
```

How would recommend solving it?

cc @broccolini