### PR TITLE
update electron-releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2809,9 +2809,9 @@
       "integrity": "sha512-Y1HtaovotrM/RP1eu5qYfQhl+SpCyBHVnYflsKJExBKMMvMODi82S1o7Jd89NzsYR9fc8YqHm7W7FyhPllb3dg=="
     },
     "electron-i18n": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-0.61.0.tgz",
-      "integrity": "sha512-PIZ3G7qxxmSbiF6kvP0l/K5KiL3Nd1NeOTYYnsB7+H6epTtF8Z/QkTQK4/ZxVSKsWNgg2XPM+Ii9S5apWZBRgg=="
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-0.62.0.tgz",
+      "integrity": "sha512-V6iw0og7W9jjgB+rMrikL2rZilXBK9dXPT81S18JoMRt43JWXPweNYDO2tUisFCCzl21nCHWvI1tcGsUA/L7Lg=="
     },
     "electron-npm-packages": {
       "version": "3.0.0",
@@ -2819,9 +2819,9 @@
       "integrity": "sha512-BvZP9q131CgD2OZ/cb6LtL0T2zVb+lw35L6OVVXGHcSL7OoJadukvjPh2UyJfWPldbKS6W2M5O58TIHpYeaD2Q=="
     },
     "electron-releases": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.2.0.tgz",
-      "integrity": "sha512-bf+wGfS/3QhnW08TeqZzMoDCsaiAq1a4h7ROkVGuIxlY+NYecxZ/kAzROsKTAgu2NjrOqH/sLMfkPS3PQf3lCg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.5.0.tgz",
+      "integrity": "sha512-/6leCrPMXbWaFLE6Ep7ZzRjItFGXhXd6yj12sfAu8Rim2kYb7e/tXvozjrTx930IG7RSXRUtvqI3lN1BYIEHQg=="
     },
     "electron-to-chromium": {
       "version": "1.3.26",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-apps": "1.2227.0",
     "electron-i18n": "0.62.0",
     "electron-npm-packages": "3.0.0",
-    "electron-releases": "2.2.0",
+    "electron-releases": "^2.5.0",
     "electron-userland-reports": "1.6.0",
     "express": "^4.16.2",
     "express-graphql": "^0.6.11",


### PR DESCRIPTION
Looks like because the releases came out so soon after one another during the security patching, the earlier version of `electron-releases` got merged instead of the latest in #1030, resulting in outdated info on https://www.electronjs.org/releases. 