### PR TITLE
Two versions on homepage

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -50,6 +50,8 @@ community:
     To add a meetup, edit <code>data/meetups.json</code> and
     <a href="https://github.com/electron/electronjs.org/tree/master/data/meetups.json">make a pull request</a>.
 
+releases: Releases
+
 electron_is_easy:
   title: It's easier than you think
   description:

--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -19,6 +19,9 @@ module.exports = function contextBuilder (req, res, next) {
 
   const localized = i18n.website[req.language]
 
+  const stableRelease = releases.find(release => release.npm_dist_tag === 'latest')
+  const betaRelease = releases.find(release => release.npm_dist_tag === 'beta')
+
   // Page titles, descriptions, etc
   let page = Object.assign({
     title: 'Electron',
@@ -39,7 +42,9 @@ module.exports = function contextBuilder (req, res, next) {
     locales: i18n.locales,
     page: page,
     localized: localized,
-    cookies: req.cookies
+    cookies: req.cookies,
+    stableRelease,
+    betaRelease
   }
 
   if (req.path.startsWith('/docs')) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-apps": "1.2391.0",
     "electron-i18n": "0.120.0",
     "electron-npm-packages": "3.0.0",
-    "electron-releases": "2.11.0",
+    "electron-releases": "^2.11.2",
     "electron-userland-reports": "1.6.0",
     "express": "^4.16.2",
     "express-graphql": "^0.6.11",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-apps": "1.2391.0",
     "electron-i18n": "0.120.0",
     "electron-npm-packages": "3.0.0",
-    "electron-releases": "^2.11.2",
+    "electron-releases": "2.11.2",
     "electron-userland-reports": "1.6.0",
     "express": "^4.16.2",
     "express-graphql": "^0.6.11",

--- a/styles/_home.scss
+++ b/styles/_home.scss
@@ -10,43 +10,13 @@
 
 // Headers ------------------------------
 
-// Electron version
-.electron-versions {
-  display: inline-block;
-  margin: 0 auto;
-  color: $main-color-subtle;
-  font-size: .88em;
-
-  @include breakpoint(md) {
-    display: table;
-  }
+.nodejs-color {
+  color: $nodejs-color;
 }
 
-.electron-versions span {
-  display: inline-block;
-  line-height: 1;
-  padding: 0.6em 0.8em;
-  white-space: nowrap;
-
-  @include breakpoint(md) {
-    display: table-cell;
-    & + span:not(:last-child) {
-      border-right: 1px solid $border-color;
-    }
-  }
+.chromium-color {
+  color: $chromium-color;
 }
-
-.electron-versions strong {
-  color: $main-color-strong;
-}
-
-.electron-versions-main {
-  border-radius: 3px;
-  color: $main-color;
-  border: 1px solid $border-color;
-  background-color: lighten($sub-bg-color, 6%);
-}
-
 
 // Features ------------------------------
 

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -44,4 +44,7 @@ $border-color: $main-border-color;
 // Default: $container-max-widths: ( xl: 1260px );
 $grid-breakpoints: map-merge($grid-breakpoints, (xl: 1300px));
 
-$code-font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace
+$code-font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+
+$nodejs-color: #65AA4C;
+$chromium-color: #5586EB

--- a/test/index.js
+++ b/test/index.js
@@ -50,20 +50,29 @@ describe('electronjs.org', () => {
   })
 
   describe('homepage', () => {
-    test('displays featured apps, version numbers, and CoC link', async () => {
+    test('displays electron version data for latest and beta', async () => {
+      const $ = await get('/')
+      $('#electron-version-latest').text().should.match(/npm i -D electron@latest/)
+      $('#electron-version-latest').text().should.match(/Electron\s+\d+\.\d+\.\d+/)
+      $('#electron-version-latest').text().should.match(/Node\s+\d+\.\d+\.\d+/)
+      $('#electron-version-latest').text().should.match(/Chromium\s+\d+\.\d+\.\d+\.\d+/)
+
+      $('#electron-version-beta').text().should.match(/npm i -D electron@beta/)
+      $('#electron-version-beta').text().should.match(/Electron\s+\d+\.\d+\.\d+/)
+      $('#electron-version-beta').text().should.match(/Node\s+\d+\.\d+\.\d+/)
+      $('#electron-version-beta').text().should.match(/Chromium\s+\d+\.\d+\.\d+\.\d+/)
+    })
+
+    test('displays featured apps', async () => {
       const $ = await get('/')
       $('header').should.have.class('site-header')
       $('p.jumbotron-lead').should.contain('Build cross platform desktop apps')
       $('.featured-app').length.should.equal(24)
       $('head > title').text().should.match(/^Electron/)
+    })
 
-      // versions
-      $('#electron-versions').text().should.match(/Electron: \d+\.\d+\.\d+/)
-      $('#electron-versions').text().should.match(/Node: \d+\.\d+\.\d+/)
-      $('#electron-versions').text().should.match(/Chromium: \d+\.\d+\.\d+\.\d+/)
-      $('#electron-versions').text().should.match(/V8: \d+\.\d+\.\d+\.\d+/)
-
-      // Footer
+    test('displays Code of Conduct link in the footer', async () => {
+      const $ = await get('/')
       $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md"]')
         .text().should.eq('Code of Conduct')
     })

--- a/views/home.html
+++ b/views/home.html
@@ -8,7 +8,7 @@
 </div>
 
 <div class="container">
-    <h1 class="text-center-sm"><a href="/releases">{{localized.releases}}</a></h1>
+    <h1 class="text-center"><a href="/releases">{{localized.releases}}</a></h1>
       <div class="col-ms-12 col-lg-6">
         <figure class="highlight highlight-dark text-left my-3 px-2">
             <pre><code>$ npm i -D electron@latest

--- a/views/home.html
+++ b/views/home.html
@@ -7,15 +7,25 @@
   </div>
 </div>
 
-<div class="subtron py-4 text-center">
-  <div class="container">
-    <div id="electron-versions" class="electron-versions">
-      <span class="electron-versions-main">Electron: <strong>{{{deps.version}}}</strong></span>
-      <span>Node: <strong>{{{deps.node}}}</strong></span>
-      <span>Chromium: <strong>{{{deps.chrome}}}</strong></span>
-      <span>V8: <strong>{{{deps.v8}}}</strong></span>
-    </div>
-  </div>
+<div class="container">
+    <h1 class="text-center-sm"><a href="/releases">{{localized.releases}}</a></h1>
+      <div class="col-ms-12 col-lg-6">
+        <figure class="highlight highlight-dark text-left my-3 px-2">
+            <pre><code>$ npm i -D electron@latest
+<span class="c1"># Electron   {{{stableRelease.version}}}
+# Node.js    {{stableRelease.deps.node}}
+# Chromium   {{stableRelease.deps.chrome}}</span></code></pre></figure>
+        <!-- <span class="nodejs-color mr-3"><i class="devicon-nodejs-plain"></i> Node.js {{stableRelease.deps.node}}</span> 
+        <span class="chromium-color"><i class="devicon-chrome-plain"></i> Chromium {{stableRelease.deps.chrome}}</span> -->
+      </div>
+      <div class="col-ms-12 col-lg-6 px-3">
+
+          <figure class="highlight highlight-dark text-left my-3 px-3">
+              <pre><code>$ npm i -D electron@beta
+<span class="c1"># Electron   {{{betaRelease.version}}}
+# Node.js    {{betaRelease.deps.node}}
+# Chromium   {{betaRelease.deps.chrome}}</span></code></pre></figure>
+      </div>
 </div>
 
 <section class="page-section page-section-spacious" id='electron'>

--- a/views/home.html
+++ b/views/home.html
@@ -10,20 +10,18 @@
 <div class="container">
     <h1 class="text-center"><a href="/releases">{{localized.releases}}</a></h1>
       <div class="col-xs-12 col-md-6">
-        <figure class="highlight highlight-dark text-left my-3 px-2">
+        <figure id="electron-version-latest" class="highlight highlight-dark text-left my-3 px-2">
             <pre><code>$ npm i -D electron@latest
 <span class="c1"># Electron   {{{stableRelease.version}}}
-# Node.js    {{stableRelease.deps.node}}
+# Node       {{stableRelease.deps.node}}
 # Chromium   {{stableRelease.deps.chrome}}</span></code></pre></figure>
-        <!-- <span class="nodejs-color mr-3"><i class="devicon-nodejs-plain"></i> Node.js {{stableRelease.deps.node}}</span> 
-        <span class="chromium-color"><i class="devicon-chrome-plain"></i> Chromium {{stableRelease.deps.chrome}}</span> -->
       </div>
       <div class="col-xs-12 col-md-6">
 
-          <figure class="highlight highlight-dark text-left my-3 px-3">
+          <figure id="electron-version-beta" class="highlight highlight-dark text-left my-3 px-3">
               <pre><code>$ npm i -D electron@beta
 <span class="c1"># Electron   {{{betaRelease.version}}}
-# Node.js    {{betaRelease.deps.node}}
+# Node       {{betaRelease.deps.node}}
 # Chromium   {{betaRelease.deps.chrome}}</span></code></pre></figure>
       </div>
 </div>

--- a/views/home.html
+++ b/views/home.html
@@ -9,7 +9,7 @@
 
 <div class="container">
     <h1 class="text-center"><a href="/releases">{{localized.releases}}</a></h1>
-      <div class="col-ms-12 col-lg-6">
+      <div class="col-xs-12 col-md-6">
         <figure class="highlight highlight-dark text-left my-3 px-2">
             <pre><code>$ npm i -D electron@latest
 <span class="c1"># Electron   {{{stableRelease.version}}}
@@ -18,7 +18,7 @@
         <!-- <span class="nodejs-color mr-3"><i class="devicon-nodejs-plain"></i> Node.js {{stableRelease.deps.node}}</span> 
         <span class="chromium-color"><i class="devicon-chrome-plain"></i> Chromium {{stableRelease.deps.chrome}}</span> -->
       </div>
-      <div class="col-ms-12 col-lg-6 px-3">
+      <div class="col-xs-12 col-md-6">
 
           <figure class="highlight highlight-dark text-left my-3 px-3">
               <pre><code>$ npm i -D electron@beta


### PR DESCRIPTION
Resolves #934 

This is an update to display the `latest` and `beta` version info on the homepage, instead of just `latest`.

Here's a shot at the visual:

<img width="619" alt="screen shot 2018-02-21 at 2 38 59 pm" src="https://user-images.githubusercontent.com/2289/36509779-a4060256-1715-11e8-8ca0-2a84ebe32dc3.png">

I was also trying out using devicons for Node.js and Chromium (forgive the redundant info in this transitional screenshot):

<img width="434" alt="screen shot 2018-02-21 at 2 39 54 pm" src="https://user-images.githubusercontent.com/2289/36509846-d17ae3fa-1715-11e8-9d28-cace7cfcf330.png">

To Do

- [x] Figure out out how to get each side to fill up 50% of available viewport width
- [ ] Wait for an updated version of [electron-releases](https://github.com/electron/electron-releases) that includes Chrome and Node version data from S3.
- [x] Explore other ways of displaying this info.

@simurai feel free to take a turn on this PR if you have the time and energy!


