### PR TITLE
Remove scrollbar on release version info box

### DIFF
--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -76,6 +76,10 @@ img[data-src] {
   opacity: 0;
 }
 
+.overflow-hidden {
+  overflow: hidden  !important;
+}
+
 
 // add top margin
 // to make it easier to see headers within a long wall of text

--- a/views/home.html
+++ b/views/home.html
@@ -11,7 +11,7 @@
     <h1 class="text-center"><a href="/releases">{{localized.releases}}</a></h1>
       <div class="col-xs-12 col-md-6">
         <figure id="electron-version-latest" class="highlight highlight-dark text-left my-3 px-2">
-            <pre><code>$ npm i -D electron@latest
+            <pre class="overflow-hidden"><code>$ npm i -D electron@latest
 <span class="c1"># Electron   {{{stableRelease.version}}}
 # Node       {{stableRelease.deps.node}}
 # Chromium   {{stableRelease.deps.chrome}}</span></code></pre></figure>
@@ -19,7 +19,7 @@
       <div class="col-xs-12 col-md-6">
 
           <figure id="electron-version-beta" class="highlight highlight-dark text-left my-3 px-3">
-              <pre><code>$ npm i -D electron@beta
+              <pre class="overflow-hidden"><code>$ npm i -D electron@beta
 <span class="c1"># Electron   {{{betaRelease.version}}}
 # Node       {{betaRelease.deps.node}}
 # Chromium   {{betaRelease.deps.chrome}}</span></code></pre></figure>


### PR DESCRIPTION
There's currently an unsightly scrollbar on the release version boxes :( 
(on Chrome and Safari)
![image](https://user-images.githubusercontent.com/6842965/36555900-a4419304-1803-11e8-99b8-55c11b37c8cd.png)
