### PR TITLE
fix(blog): Bump protocol handler fix versions

### DIFF
--- a/data/blog/protocol-handler-fix.md
+++ b/data/blog/protocol-handler-fix.md
@@ -25,9 +25,9 @@ macOS and Linux are **not vulnerable** to this issue.
 
 We've published new versions of Electron which include fixes for 
 this vulnerability: 
-[`1.8.2-beta.4`](https://github.com/electron/electron/releases/tag/v1.8.2-beta.4), 
-[`1.7.11`](https://github.com/electron/electron/releases/tag/v1.7.11), 
-and [`1.6.16`](https://github.com/electron/electron/releases/tag/v1.6.16).
+[`1.8.2-beta.5`](https://github.com/electron/electron/releases/tag/v1.8.2-beta.5),
+[`1.7.12`](https://github.com/electron/electron/releases/tag/v1.7.12),
+and [`1.6.17`](https://github.com/electron/electron/releases/tag/v2.6.17).
 We urge all Electron developers to update their apps to the latest stable 
 version immediately.
 


### PR DESCRIPTION
Since we followed up with a case-insensitive variant of the
original fix, the blog post's recommendations for mitigating
the fix with a new version should point to the updated fix.