### PR TITLE
Use greenkeeper-lockfile to update package-lock.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ node_js:
   - "8"
 notifications:
   email: false
+before_install:
+# package-lock.json was introduced in npm@5
+  - '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
+  - npm install -g greenkeeper-lockfile@1
+before_script: greenkeeper-lockfile-update
+after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
Right now, greenkeeper only updates dependencies in `package.json`. This PR adds `greenkeeper-lockfile` to update `package-lock.json` too as part of the CI build process. I just followed the setup instruction for Travis [here](https://github.com/greenkeeperio/greenkeeper-lockfile#setup).