### PR TITLE
Add OpenCollective donors page

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -2,6 +2,7 @@ tagline: Build cross platform desktop apps with JavaScript, HTML, and CSS
 
 nav:
   docs: Docs
+  donors: Donors
   blog: Blog
   community: Community
   apps: Apps
@@ -193,6 +194,8 @@ pages:
   '/spectron':
     title: Spectron
     description: Spectron is an open source framework for easily writing integrations tests for your Electron app. Built on top of ChromeDriver and WebDriverIO.
+  '/donors':
+    title: Donors
 
 _404:
   page_not_found: Page not found.

--- a/routes/donors.js
+++ b/routes/donors.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+    res.render('donors', req.context)
+}

--- a/server.js
+++ b/server.js
@@ -88,6 +88,7 @@ app.get('/spectron', routes.spectron)
 app.get('/userland', routes.userland.index)
 app.get('/userland/*', routes.userland.show)
 app.use('/crowdin', routes.languages.proxy)
+app.use('/donors', routes.donors)
 app.get('/search/:searchIn*?', routes.search.index)
 
 // Generic 404 handler

--- a/views/donors.html
+++ b/views/donors.html
@@ -1,0 +1,6 @@
+<section class='page-section'>
+  <div class='container-narrow text-center py-md-8'>
+      <h1>Donors</h1>
+      <script src="https://opencollective.com/electron/banner.js"></script>
+    </div>
+</section>

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -17,6 +17,7 @@
     </a>
 
     <nav class="site-header-nav">
+      <a class="site-header-nav-item" href="/donors">{{localized.nav.donors}}</a>
       <a class="site-header-nav-item" href="/search">{{localized.nav.search}}</a>
       <a class="site-header-nav-item" href="/apps">{{localized.nav.apps}}</a>
       <a class="site-header-nav-item" href="/docs">{{localized.nav.docs}}</a>


### PR DESCRIPTION
Created a `/donors` page. The contents is rendered from opencollective.com so it may or may not have a style that matches our theme at first. We can probably improve it down the road.

- [x] `/donors` route
- [x] menu item
- [x] donors localization

See: https://opencollective.com/electron
