### PR TITLE
disable donors in nav

### DIFF
--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -17,7 +17,7 @@
     </a>
 
     <nav class="site-header-nav">
-      <a class="site-header-nav-item" href="/donors">{{localized.nav.donors}}</a>
+      <!-- <a class="site-header-nav-item" href="/donors">{{localized.nav.donors}}</a> -->
       <a class="site-header-nav-item" href="/search">{{localized.nav.search}}</a>
       <a class="site-header-nav-item" href="/apps">{{localized.nav.apps}}</a>
       <a class="site-header-nav-item" href="/docs">{{localized.nav.docs}}</a>


### PR DESCRIPTION
Let's not link to the @opencollective donors page until we have donors.

cc @groundwater 