### PR TITLE
default to English if lang param is invalid

### DIFF
--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -17,6 +17,10 @@ module.exports = function contextBuilder (req, res, next) {
     req.language = req.query.lang
   }
 
+  // If request language does not exist, fall back to English
+  // e.g. /?lang=Foo
+  if (!i18n.website[req.language]) req.language = 'en-US'
+
   const localized = i18n.website[req.language]
 
   const stableRelease = releases.find(release => release.npm_dist_tag === 'latest')

--- a/test/index.js
+++ b/test/index.js
@@ -179,6 +179,11 @@ describe('electronjs.org', () => {
       $('.error-page').text().should.include('Page not found')
     })
 
+    test('//index.php?lang=Cn&index=0000', async () => {
+      const res = await supertest(app).get('//index.php?lang=Cn&index=0000')
+      res.statusCode.should.equal(404)
+    })
+
     test('docs footer', async () => {
       // includes a link to edit the doc
       const $ = await get('/docs/api/accelerator')


### PR DESCRIPTION
Fixes 500 errors for requests like`//index.php?lang=Cn&index=0000`

![image](https://user-images.githubusercontent.com/2289/37925349-1f557d28-30e9-11e8-9c8e-5c172bf646e0.png)
