### PR TITLE
disable-sass-debugging

### DIFF
--- a/middleware/sass.js
+++ b/middleware/sass.js
@@ -5,7 +5,7 @@ module.exports = function () {
   return sass({
     src: path.join(__dirname, '../styles'),
     response: true,
-    debug: true,
+    debug: false,
     includePaths: path.join(__dirname, '../node_modules'),
     // outputStyle: 'compressed',
     prefix: '/styles'


### PR DESCRIPTION
I accidentally left sass in `debug` mode a while back and it was spewing output into the test results. This turns it back off. 🚒 