### PR TITLE
Translate on Crowdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "connect-slashes": "^1.3.1",
     "cookie-parser": "^1.4.3",
     "cross-env": "^5.1.1",
+    "crowdin-editor-language-codes": "^1.0.0",
     "description": "0.0.4",
     "dotenv": "^5.0.0",
     "electron-api-historian": "^1.1.1",

--- a/routes/docs/show.js
+++ b/routes/docs/show.js
@@ -9,7 +9,7 @@ module.exports = (req, res, next) => {
 
   // Crowdin's undocumented mystery locale URL format. See https://git.io/vADu0
   // e.g. `zh-CN` -> `zhcn`
-  const {editorCode} = editorCodes[req.context.currentLocale]
+  const {editorCode} = editorCodes[req.context.currentLocale] || {}
 
   doc.crowdinUrl = editorCode
     ? `https://crowdin.com/translate/electron/${doc.crowdinFileId}/en-${editorCode}`

--- a/routes/docs/show.js
+++ b/routes/docs/show.js
@@ -1,10 +1,19 @@
 const i18n = require('../../lib/i18n')
+const editorCodes = require('crowdin-editor-language-codes')
 
 module.exports = (req, res, next) => {
   const doc = i18n.docs[req.language][req.path]
   const docEn = req.context.currentLocale.startsWith('en')
     ? null : i18n.docs['en-US'][req.path]
   if (!doc) return next()
+
+  // Crowdin's undocumented mystery locale URL format. See https://git.io/vADu0
+  // e.g. `zh-CN` -> `zhcn`
+  const {editorCode} = editorCodes[req.context.currentLocale]
+
+  doc.crowdinUrl = editorCode
+    ? `https://crowdin.com/translate/electron/${doc.crowdinFileId}/en-${editorCode}`
+    : 'https://crowdin.com/project/electron'
 
   const context = Object.assign(req.context, {
     doc: doc,

--- a/routes/docs/show.js
+++ b/routes/docs/show.js
@@ -9,7 +9,8 @@ module.exports = (req, res, next) => {
 
   // Crowdin's undocumented mystery locale URL format. See https://git.io/vADu0
   // e.g. `zh-CN` -> `zhcn`
-  const {editorCode} = editorCodes[req.context.currentLocale] || {}
+  const {languageCode} = i18n.locales[req.context.currentLocale] || {}
+  const {editorCode} = editorCodes[languageCode] || {}
 
   doc.crowdinUrl = editorCode
     ? `https://crowdin.com/translate/electron/${doc.crowdinFileId}/en-${editorCode}`

--- a/test/index.js
+++ b/test/index.js
@@ -382,6 +382,7 @@ describe('electronjs.org', () => {
       for (let lang of langs) {
         res = await supertest(app).get(`/docs/api/browser-window?lang=${lang}`)
         res.statusCode.should.be.equal(200)
+        res.statusCode.should.equal(200)
       }
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -190,6 +190,14 @@ describe('electronjs.org', () => {
         $('.propose-change').attr('href').should.eq('https://github.com/electron/electron/tree/master/docs/api/accelerator.md')
       })
 
+      test('includes a link to translate the doc on Crowdin', async () => {
+        const res = await supertest(app)
+          .get('/docs/api/accelerator')
+          .set('Cookie', ['language=zh-CN'])
+        const $ = cheerio.load(res.text)
+        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/63/en-zhcn')
+      })
+
       test('includes a link to view doc history', async () => {
         const $ = await get('/docs/api/accelerator/history')
         // $('body').text().should.include('The Accelerator API was introduced in Electron v0.15.3')

--- a/test/index.js
+++ b/test/index.js
@@ -198,14 +198,22 @@ describe('electronjs.org', () => {
         $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/63/en-zhcn')
       })
 
-      test('includes a link to translate en-US on Crowdin, even though it is not a target language', async () => {
+      test('includes a link to translate the doc on Crowdin for Indonesian', async () => {
+        const res = await supertest(app)
+          .get('/docs/api/crash-reporter')
+          .set('Cookie', ['language=id-ID'])
+        const $ = cheerio.load(res.text)
+        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/74/en-id')
+      })
+
+      test('includes a link to Crowdin language picker when language is English', async () => {
         // Crowdin displays a nice language picker when target language does not exist
         // See https://git.io/vx1TI
         const res = await supertest(app)
           .get('/docs/api/browser-view')
           .set('Cookie', ['language=en-US'])
         const $ = cheerio.load(res.text)
-        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/66/en-enus')
+        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/66/en-en')
       })
 
       test('includes a link to view doc history', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -198,6 +198,16 @@ describe('electronjs.org', () => {
         $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/63/en-zhcn')
       })
 
+      test('includes a link to translate en-US on Crowdin, even though it is not a target language', async () => {
+        // Crowdin displays a nice language picker when target language does not exist
+        // See https://git.io/vx1TI
+        const res = await supertest(app)
+          .get('/docs/api/browser-view')
+          .set('Cookie', ['language=en-US'])
+        const $ = cheerio.load(res.text)
+        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/66/en-enus')
+      })
+
       test('includes a link to view doc history', async () => {
         const $ = await get('/docs/api/accelerator/history')
         // $('body').text().should.include('The Accelerator API was introduced in Electron v0.15.3')

--- a/test/index.js
+++ b/test/index.js
@@ -184,19 +184,18 @@ describe('electronjs.org', () => {
       res.statusCode.should.equal(404)
     })
 
-    test('docs footer', async () => {
-      // includes a link to edit the doc
-      const $ = await get('/docs/api/accelerator')
-      $('.propose-change').attr('href').should.eq('https://github.com/electron/electron/tree/master/docs/api/accelerator.md')
+    describe('docs footer', () => {
+      test('includes a link to edit the doc on GitHub', async () => {
+        const $ = await get('/docs/api/accelerator')
+        $('.propose-change').attr('href').should.eq('https://github.com/electron/electron/tree/master/docs/api/accelerator.md')
+      })
 
-      // TODO: test other docs footer links
-    })
-
-    test('doc history', async () => {
-      const $ = await get('/docs/api/accelerator/history')
-      // $('body').text().should.include('The Accelerator API was introduced in Electron v0.15.3')
-      // $('head > title').text().should.eq('accelerator Version History | Electron')
-      $('tr').length.should.be.above(10)
+      test('includes a link to view doc history', async () => {
+        const $ = await get('/docs/api/accelerator/history')
+        // $('body').text().should.include('The Accelerator API was introduced in Electron v0.15.3')
+        // $('head > title').text().should.eq('accelerator Version History | Electron')
+        $('tr').length.should.be.above(10)
+      })
     })
   })
 

--- a/views/layouts/docs.html
+++ b/views/layouts/docs.html
@@ -49,7 +49,7 @@
         {{localized.docs.footer.propose_change}}
       </a>
       
-      <a class="mr-4" href='https://crowdin.com/project/electron'>
+      <a class="mr-4 translate-on-crowdin" href='{{doc.crowdinUrl}}'></a>
         <span class="octicon octicon-globe"></span>
         {{localized.docs.footer.translate}}
       </a>

--- a/views/layouts/docs.html
+++ b/views/layouts/docs.html
@@ -49,7 +49,7 @@
         {{localized.docs.footer.propose_change}}
       </a>
       
-      <a class="mr-4 translate-on-crowdin" href='{{doc.crowdinUrl}}'></a>
+      <a class="mr-4 translate-on-crowdin" href='{{doc.crowdinUrl}}'>
         <span class="octicon octicon-globe"></span>
         {{localized.docs.footer.translate}}
       </a>


### PR DESCRIPTION
This is a replacement PR for #1158, the git history of which was flummoxed. Fixes #867

At long last, this PR adds a link to the footer of every doc page that takes the user straight to the right Crowdin editor page for the given file and language.

