### PR TITLE
feat: add sidebar nav to docs pages

### DIFF
--- a/routes/docs/show.js
+++ b/routes/docs/show.js
@@ -26,7 +26,7 @@ module.exports = (req, res, next) => {
       url: req.url,
     },
     layout: 'docs',
-    nav: i18n.navs[req.context.currentLocale]
+    nav: i18n.navs[req.context.currentLocale],
   })
 
   res.render('docs/show', context)

--- a/routes/docs/show.js
+++ b/routes/docs/show.js
@@ -26,6 +26,7 @@ module.exports = (req, res, next) => {
       url: req.url,
     },
     layout: 'docs',
+    nav: i18n.navs[req.context.currentLocale]
   })
 
   res.render('docs/show', context)

--- a/views/layouts/docs.html
+++ b/views/layouts/docs.html
@@ -45,7 +45,7 @@
 </div>
 
 <div class='py-6 py-md-7 py-lg-8'>
-  <div class='container-lg p-responsive docs strong-headers'>
+  <div class='container-xl p-responsive docs strong-headers'>
     <div class="row">
       <div class="col-xs-12 col-md-3">
         {{#if doc.isTutorial}}
@@ -63,7 +63,7 @@
           </ul>
         {{/if}}
       </div>
-      <div class="col-xs-12 col-md-9 container-narrow">
+      <div class="col-xs-12 col-md-6 container-narrow">
         <div class="markdown-body">{{{body}}}</div>
         <hr>
         <div class="doc-actions text-center">
@@ -82,6 +82,13 @@
             {{localized.docs.footer.version_history}}
           </a>
         </div>
+      </div>
+      <div class="col-xs-12 col-md-3">
+        <ul>
+          {{#each doc.sections}}
+            <li><a>{{this.name}}</a></li>
+          {{/each}}
+        </ul>
       </div>
     </div>
   </div>

--- a/views/layouts/docs.html
+++ b/views/layouts/docs.html
@@ -46,26 +46,44 @@
 
 <div class='py-6 py-md-7 py-lg-8'>
   <div class='container-lg p-responsive docs strong-headers'>
-    <div class="markdown-body">{{{body}}}</div>
-    <hr>
+    <div class="row">
+      <div class="col-xs-12 col-md-3">
+        {{#if doc.isTutorial}}
+          {{{nav}}}
+        {{/if}}
+        {{#if doc.isApiDoc}}
+          <ul>
+            {{#each docs}}
+              {{#if this.isApiDoc}}
+                <li>
+                  <a href="{{this.href}}">{{this.title}}</a>
+                </li>
+              {{/if}}
+            {{/each}}
+          </ul>
+        {{/if}}
+      </div>
+      <div class="col-xs-12 col-md-9 container-narrow">
+        <div class="markdown-body">{{{body}}}</div>
+        <hr>
+        <div class="doc-actions text-center">
+          <a class="mr-4 propose-change" href='{{doc.githubUrl}}'>
+            <span class="octicon octicon-mark-github"></span>
+            {{localized.docs.footer.propose_change}}
+          </a>
 
-    <div class="doc-actions text-center">
-      <a class="mr-4 propose-change" href='{{doc.githubUrl}}'>
-        <span class="octicon octicon-mark-github"></span>
-        {{localized.docs.footer.propose_change}}
-      </a>
+          <a class="mr-4 translate-on-crowdin" href='{{doc.crowdinUrl}}'>
+            <span class="octicon octicon-globe"></span>
+            {{localized.docs.footer.translate}}
+          </a>
 
-      <a class="mr-4 translate-on-crowdin" href='{{doc.crowdinUrl}}'>
-        <span class="octicon octicon-globe"></span>
-        {{localized.docs.footer.translate}}
-      </a>
-
-      <a class="mr-4" href='{{doc.href}}/history'>
-        <span class="octicon octicon-history"></span>
-        {{localized.docs.footer.version_history}}
-      </a>
+          <a class="mr-4" href='{{doc.href}}/history'>
+            <span class="octicon octicon-history"></span>
+            {{localized.docs.footer.version_history}}
+          </a>
+        </div>
+      </div>
     </div>
-
   </div>
 </div>
 </main>


### PR DESCRIPTION
Resolves #1156 

This PR adds a (localized) sidebar to documentation pages. For tutorial docs, it displays the nested table of contents extracted from [electron/electron/docs/README.md#guides-and-tutorials](https://github.com/electron/electron/blob/master/docs/README.md#guides-and-tutorials).

For API docs, the sidebar displays a list of all APIs.

To Do

- [ ] Make it look better. Currently it's a vanilla unordered list.
- [ ] Fix the left-alignment of the page heading and breadcrumbs.
- [ ] Visually emphasize the currently active link (probably using client-side JavaScript)
- [ ] Display the new nested tutorials nav on the /docs index page too
- [ ] Make it look decent on mobile devices. Maybe the answer is to hide hide the sidebar entirely on mobile.