### PR TITLE
obfuscate email addresses

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -21,14 +21,14 @@ locales.forEach(locale => {
   })
 })
 
-function containsEmail(string) {
-  return typeof string === 'string' && string.match(emailPattern)  
+function containsEmail (string) {
+  return typeof string === 'string' && string.match(emailPattern)
 }
 
-function obfuscate(string) {
+function obfuscate (string) {
   return string.replace(emailPattern, match => {
     return Array.prototype.map.call(match, chr => {
-        return `&#${chr.charCodeAt(0)};`
+      return `&#${chr.charCodeAt(0)};`
     }).join('')
   })
 }

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -6,6 +6,7 @@ const {get, set} = require('lodash')
 const locales = Object.keys(i18n.locales)
 const websiteStrings = require('../data/locale.yml')
 const websiteKeys = Object.keys(flat(websiteStrings))
+const emailPattern = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
 
 // If any website strings are missing from electron-i18n,
 // fill them in with the corresponding value from ../data/locale.yml
@@ -18,6 +19,27 @@ locales.forEach(locale => {
       set(i18n, deepKey, get(websiteStrings, key))
     }
   })
+})
+
+function containsEmail(string) {
+  return typeof string === 'string' && string.match(emailPattern)  
+}
+
+function obfuscate(string) {
+  return string.replace(emailPattern, match => {
+    return Array.prototype.map.call(match, chr => {
+        return `&#${chr.charCodeAt(0)};`
+    }).join('')
+  })
+}
+
+const keys = Object.keys(flat(i18n))
+
+keys.forEach(key => {
+  const value = get(i18n, key)
+  if (containsEmail(value)) {
+    set(i18n, key, obfuscate(value))
+  }
 })
 
 module.exports = i18n

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -1,0 +1,25 @@
+require('require-yaml')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const chai = require('chai')
+chai.should()
+const i18n = require('../lib/i18n')
+const i18nVanilla = require('../data/locale.yml')
+
+describe('i18n', () => {
+  it('vanilla locale object has unobfuscated email addresses', () => {
+    const channels = i18nVanilla.community.channels
+    channels.security.should.include('security@electronjs.org')
+    channels.code_of_conduct.should.include('coc@electronjs.org')
+    channels.other.should.include('info@electronjs.org')
+  })
+
+  it('processed locale object has obfuscated email addresses', () => {
+    const channels = i18n.website['en-US'].community.channels
+    channels.security.should.not.include('security@electronjs.org')
+    channels.code_of_conduct.should.not.include('coc@electronjs.org')
+    channels.other.should.not.include('info@electronjs.org')
+    channels.security.should.include('mailto:&#115;&#101;&#99;&#117;&#114;&#105;&#116;&#121;&#64;&#101;&#108;&#101;&#99;&#116;&#114;&#111;&#110;&#106;&#115;&#46;&#111;&#114;&#103;')
+  })
+})
+

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -1,6 +1,6 @@
 require('require-yaml')
 
-const { describe, it, beforeEach, afterEach } = require('mocha')
+const { describe, it } = require('mocha')
 const chai = require('chai')
 chai.should()
 const i18n = require('../lib/i18n')
@@ -22,4 +22,3 @@ describe('i18n', () => {
     channels.security.should.include('mailto:&#115;&#101;&#99;&#117;&#114;&#105;&#116;&#121;&#64;&#101;&#108;&#101;&#99;&#116;&#114;&#111;&#110;&#106;&#115;&#46;&#111;&#114;&#103;')
   })
 })
-


### PR DESCRIPTION
This PR obfuscates email addresses in locale.yml at server startup by encoding them as HTML entities.

🍐 @codebytere 