### PR TITLE
Support right-to-left languages

### DIFF
--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -2,6 +2,7 @@ const i18n = require('lib/i18n')
 const releases = require('electron-releases')
 const {deps} = releases.find(release => release.version === i18n.electronLatestStableVersion)
 const {getLanguageNativeName} = require('locale-code')
+const rtlDetect = require('rtl-detect')
 
 // Supply all route handlers with a baseline `req.context` object
 module.exports = function contextBuilder (req, res, next) {
@@ -43,6 +44,7 @@ module.exports = function contextBuilder (req, res, next) {
     deps: deps,
     currentLocale: req.language,
     currentLocaleNativeName: getLanguageNativeName(req.language),
+    languageDirection: rtlDetect.getLangDir(req.language),
     locales: i18n.locales,
     page: page,
     localized: localized,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3371,7 +3371,12 @@
     "electron-releases": {
       "version": "2.40.0",
       "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.40.0.tgz",
+<<<<<<< HEAD
       "integrity": "sha512-F08c/a8mRMMT1TYGnaYOUQBsXcwt0ljASL0nFVlGid23iYgj5Lwbhit7wCJhdc8g6TznR5fIhnaQ5XhK5Xjukw=="
+=======
+      "integrity": "sha512-F08c/a8mRMMT1TYGnaYOUQBsXcwt0ljASL0nFVlGid23iYgj5Lwbhit7wCJhdc8g6TznR5fIhnaQ5XhK5Xjukw==",
+      "dev": true
+>>>>>>> add language direction attribute to html tag
     },
     "electron-to-chromium": {
       "version": "1.3.47",
@@ -10307,6 +10312,11 @@
       "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-1.0.2.tgz",
       "integrity": "sha1-nr4lsaLFJ3PL5vHb6Q68lRgIkAk=",
       "dev": true
+    },
+    "rtl-detect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.0.2.tgz",
+      "integrity": "sha512-5X1422hvphzg2a/bo4tIDbjFjbJUOaPZwqE6dnyyxqwFqfR+tBcvfqapJr0o0VygATVCGKiODEewhZtKF+90AA=="
     },
     "run-async": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "require-dir": "^1.0.0",
     "require-directory": "^2.1.1",
     "require-yaml": "0.0.1",
+    "rtl-detect": "^1.0.2",
     "schemeless": "^1.2.0",
     "semver": "^5.3.0",
     "set-query-string": "^2.2.0",

--- a/styles/_basecoat-footer.scss
+++ b/styles/_basecoat-footer.scss
@@ -36,6 +36,10 @@
   }
 }
 
+html[dir="rtl"] .ltr-only {
+  display: none;
+}
+
 // swap social links and nav for right-to-left languages
 html[dir="rtl"] {
   .footer-nav {  

--- a/styles/_basecoat-footer.scss
+++ b/styles/_basecoat-footer.scss
@@ -35,3 +35,18 @@
     float: right;
   }
 }
+
+// swap social links and nav for right-to-left languages
+html[dir="rtl"] {
+  .footer-nav {  
+    @include breakpoint(md) {
+      float: right;
+    }
+  }
+
+  .footer-social {
+    @include breakpoint(md) {
+      float: left;
+    }
+  }
+}

--- a/styles/_basecoat-navigation.scss
+++ b/styles/_basecoat-navigation.scss
@@ -93,3 +93,9 @@
 }
 .site-header-logo { @include breakpoint(lg) { float: left; } }
 .site-header-nav  { @include breakpoint(lg) { float: right; } }
+
+// swap logo and nav for right-to-left languages
+html[dir="rtl"] {
+  .site-header-logo { @include breakpoint(lg) { float: right; } }
+  .site-header-nav  { @include breakpoint(lg) { float: left; } }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -410,6 +410,26 @@ describe('electronjs.org', () => {
       }
     })
 
+    describe('<dir> HTML tag for right-to-left languages', () => {
+      test('is `ltr` by default', async () => {
+        const res = await supertest(app).get(`/`)
+        const $ = cheerio.load(res.text)
+        $('html').attr('dir').should.equal('ltr')
+      })
+
+      test('is `rtl` for Arabic', async () => {
+        const res = await supertest(app).get(`/?lang=ar-SA`)
+        const $ = cheerio.load(res.text)
+        $('html').attr('dir').should.equal('rtl')
+      })
+
+      test('is `rtl` for Hebrew', async () => {
+        const res = await supertest(app).get(`/?lang=he-IL`)
+        const $ = cheerio.load(res.text)
+        $('html').attr('dir').should.equal('rtl')
+      })
+    })
+
     test('redirects for date-style blog URLs', async () => {
       const res = await supertest(app).get('/blog/2017/06/01/typescript')
       res.statusCode.should.be.above(300).and.below(303)

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{currentLocale}}">
+<html lang="{{currentLocale}}" dir="{{languageDirection}}">
   {{> head}}
   <body>
     {{> header}}

--- a/views/releases/index.html
+++ b/views/releases/index.html
@@ -21,7 +21,8 @@ $ ./node_modules/.bin/electron .</code></pre>
       {{#each releases}}
         <h2 id="{{this.version}}">
           <a href="#{{this.version}}">Electron {{this.version}}</a>
-          <em data-date="{{this.created_at}}" data-format="%B %d, %Y">{{this.created_at}}</em><em>(<span data-date="{{this.created_at}}"></span>)</em>
+          <em data-date="{{this.created_at}}" data-format="%B %d, %Y">{{this.created_at}}</em>
+          <em class="ltr-only">(<span data-date="{{this.created_at}}"></span>)</em>
           <a href="{{this.html_url}}" class="octicon-wrapper"><span class="octicon octicon-mark-github vertical-middle"></span></a>
         </h2>
         


### PR DESCRIPTION
This PR adds the [`dir`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) global attribute to the layout, and uses the `req.language` property from [express-request-langauge](https://github.com/tinganho/express-request-language) to determine direction, either `ltr` or `rtl`. This should improve the site layout for rtl languages like Arabic and Hebrew.

The stylesheet has also been updated to swap the logo and nav in the header, as well as the social links and nav in the footer.

Preview URLs

- Hebrew: https://electron-website-pr-1254.herokuapp.com/languages/he-IL
- Arabic: https://electron-website-pr-1254.herokuapp.com/languages/ar-SA

Resolves #1253 

cc @talsafran