### PR TITLE
display master branch commit for tutorials

### DIFF
--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -40,6 +40,8 @@ module.exports = function contextBuilder (req, res, next) {
   req.context = {
     electronLatestStableVersion: i18n.electronLatestStableVersion,
     electronLatestStableTag: i18n.electronLatestStableTag,
+    electronMasterBranchCommit: i18n.electronMasterBranchCommit,
+    electronMasterBranchCommitShort: i18n.electronMasterBranchCommit.slice(0, 6),
     releases: releases,
     deps: deps,
     currentLocale: req.language,

--- a/views/layouts/docs.html
+++ b/views/layouts/docs.html
@@ -25,7 +25,13 @@
           / Version History
         {{else}}
           <a href="{{doc.href}}/history">
-            <span class="docs-version">{{electronLatestStableTag}}</span>
+            <span class="docs-version">
+              {{#if doc.isApiDoc}}
+                {{electronLatestStableTag}}
+              {{else}}
+                <span>electron@master ({{electronMasterBranchCommitShort}})</span>
+              {{/if}}
+            </span>
           </a>
         {{/if}}
 


### PR DESCRIPTION
For API docs:

<img width="559" alt="screen shot 2018-05-22 at 11 14 15 am" src="https://user-images.githubusercontent.com/2289/40381739-5b833732-5db1-11e8-9316-2d6f6f3fcc45.png">

For Tutorials:

<img width="627" alt="screen shot 2018-05-22 at 11 14 30 am" src="https://user-images.githubusercontent.com/2289/40381748-634fb940-5db1-11e8-85b0-d0fb8724c8e5.png">
