### PR TITLE
use full signature in API search results

### DIFF
--- a/templates/api.html
+++ b/templates/api.html
@@ -2,7 +2,7 @@
   <div class="type-title">APIs</div>
 
   <div>
-    <a href={{{url}}} style="text-decoration: none">{{{name}}}</a>
+    <a href={{{url}}} style="text-decoration: none">{{{fullSignature}}}</a>
     <div style="font-size: 10pt">{{{tldr}}}</div>
   </div>
   <a href={{{url}}}>More


### PR DESCRIPTION
Before:

<img width="350" alt="screen shot 2018-05-27 at 8 29 46 am" src="https://user-images.githubusercontent.com/2289/40587766-83288b18-6188-11e8-8545-a32a86ff9cf2.png">

After:

<img width="342" alt="screen shot 2018-05-27 at 8 29 56 am" src="https://user-images.githubusercontent.com/2289/40587768-8900eb02-6188-11e8-973e-8b81875a49e0.png">
