### PR TITLE
debug failing app platform label test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -101,6 +101,7 @@ describe('electronjs.org', () => {
 
     test('app pages apply platform labels to download links', async () => {
       const $ = await get('/apps/hyper')
+      console.log($('.app-meta').html())
       $('a.app-download.darwin').length.should.be.above(0)
       $('a.app-download.linux').length.should.be.above(0)
       $('a.app-download.win32').length.should.be.above(0)

--- a/test/index.js
+++ b/test/index.js
@@ -101,7 +101,9 @@ describe('electronjs.org', () => {
 
     test('app pages apply platform labels to download links', async () => {
       const $ = await get('/apps/hyper')
-      console.log($('.app-meta').html())
+      if ($('a.app-download.darwin').length === 0) {
+        console.log($('.app-meta').html())
+      }
       $('a.app-download.darwin').length.should.be.above(0)
       $('a.app-download.linux').length.should.be.above(0)
       $('a.app-download.win32').length.should.be.above(0)


### PR DESCRIPTION
This test is failing on Heroku, but not locally:

```js
    test('app pages apply platform labels to download links', async () => {
      const $ = await get('/apps/hyper')
      $('a.app-download.darwin').length.should.be.above(0)
      $('a.app-download.linux').length.should.be.above(0)
      $('a.app-download.win32').length.should.be.above(0)
    })
```

Added some logging temporarily to see if it fails on Travis too.