### PR TITLE
remove half-baked filter removal

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -56,9 +56,9 @@ function buildSearch (type, isPrimarySearch = false, searches) {
       // remove `is:foo` filter from query
       // TODO: figure out a way to make this affect the search
       // without affecting the input element or the query param
-      if (isolatedType) {
-        query = query.replace(`is:${isolatedType}`, '').trim()
-      }
+      // if (isolatedType) {
+      //   query = query.replace(`is:${isolatedType}`, '').trim()
+      // }
 
       // delegate query to secondary searches
       types.slice(1).forEach(type => {


### PR DESCRIPTION
We had a snippet that attempting to remove filters like `is:app` from queries, but it was having the unintended side-effect of revealing non-app results. 🤔 

So this PR disables that until we figure out a complete solution. See #1289 