### PR TITLE
Hide downloads section of sidebar for apps with no downloads #1221

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -15,12 +15,12 @@ describe('electronjs.org', () => {
   })
   it('shows downloads section for apps that have downloadable files', () => {
     cy.visit('http://localhost:5000/apps/dat')
-    cy.get('.app-meta-entry').should('be.visible')
+    cy.get('.app-meta-entry').should('contain', 'Downloads').should('be.visible')
   })
 
   it('hides downloads section for apps with no downloadable files', () => {
     cy.visit('http://localhost:5000/apps/protegopdf')
-    cy.get('.app-meta-entry').should('not.be.visible')
+    cy.get('.app-meta-entry').should('contain', 'Downloads').should('not.be.visible')
   })
 })
 

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -20,7 +20,7 @@ describe('electronjs.org', () => {
 
   it('hides downloads section for apps with no downloadable files', () => {
     cy.visit('http://localhost:5000/apps/protegopdf')
-    cy.get('.app-meta-entry').should('contain', 'Downloads').should('not.be.visible')
+    cy.wait(100).get('.app-meta-entry').should('contain', 'Downloads').should('not.be.visible')
   })
 })
 

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -15,13 +15,13 @@ describe('electronjs.org', () => {
   })
   it('shows downloads section for apps that have downloadable files', () => {
     cy.visit('http://localhost:5000/apps/dat')
-    cy.get('.app-meta-entry').should('contain', 'Downloads').should('be.visible')
+    cy.get('.app-meta').should('contain', 'Downloads').should('be.visible')
   })
 
   it('hides downloads section for apps with no downloadable files', () => {
     cy.visit('http://localhost:5000/apps/protegopdf')
     cy.wait(100)
-    cy.get('.app-meta-entry').should('contain', 'Downloads').should('not.be.visible')
+    cy.get('.app-meta').should('contain', 'Downloads').should('not.be.visible')
   })
 })
 

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -19,7 +19,7 @@ describe('electronjs.org', () => {
   })
 
   it('hides downloads section for apps with no downloadable files', () => {
-    cy.visit('http://localhost:5000/apps/protego')
+    cy.visit('http://localhost:5000/apps/protegopdf')
     cy.get('.app-meta').should('not.contain', 'Downloads')
   })
 })

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -13,6 +13,15 @@ describe('electronjs.org', () => {
     cy.get('.app-list').should('contain', 'GitHub Desktop')
     cy.get('.app-list').should('not.contain', 'gitmoji')
   })
+  it('shows downloads section for apps that have downloadable files', () => {
+    cy.visit('http://localhost:5000/apps/dat')
+    cy.get('.app-meta').should('contain', 'Downloads')
+  })
+
+  it('hides downloads section for apps with no downloadable files', () => {
+    cy.visit('http://localhost:5000/apps/protego')
+    cy.get('.app-meta').should('not.contain', 'Downloads')
+  })
 })
 
 describe('search', () => {

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -15,13 +15,13 @@ describe('electronjs.org', () => {
   })
   it('shows downloads section for apps that have downloadable files', () => {
     cy.visit('http://localhost:5000/apps/dat')
-    cy.get('.app-meta').should('contain', 'Downloads').should('be.visible')
+    cy.get('.app-meta-entry-downloads').should('be.visible')
   })
 
   it('hides downloads section for apps with no downloadable files', () => {
     cy.visit('http://localhost:5000/apps/protegopdf')
     cy.wait(100)
-    cy.get('.app-meta').should('contain', 'Downloads').should('not.be.visible')
+    cy.get('.app-meta-entry-downloads').should('not.be.visible')
   })
 })
 

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -15,12 +15,12 @@ describe('electronjs.org', () => {
   })
   it('shows downloads section for apps that have downloadable files', () => {
     cy.visit('http://localhost:5000/apps/dat')
-    cy.get('.app-meta-entry').should('contain', 'Downloads')
+    cy.get('.app-meta-entry').should('be.visible')
   })
 
   it('hides downloads section for apps with no downloadable files', () => {
     cy.visit('http://localhost:5000/apps/protegopdf')
-    cy.get('.app-meta-entry').should('not.contain', 'Downloads')
+    cy.get('.app-meta-entry').should('not.be.visible')
   })
 })
 

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -20,7 +20,8 @@ describe('electronjs.org', () => {
 
   it('hides downloads section for apps with no downloadable files', () => {
     cy.visit('http://localhost:5000/apps/protegopdf')
-    cy.wait(100).get('.app-meta-entry').should('contain', 'Downloads').should('not.be.visible')
+    cy.wait(100)
+    cy.get('.app-meta-entry').should('contain', 'Downloads').should('not.be.visible')
   })
 })
 

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -15,12 +15,12 @@ describe('electronjs.org', () => {
   })
   it('shows downloads section for apps that have downloadable files', () => {
     cy.visit('http://localhost:5000/apps/dat')
-    cy.get('.app-meta').should('contain', 'Downloads')
+    cy.get('.app-meta-entry').should('contain', 'Downloads')
   })
 
   it('hides downloads section for apps with no downloadable files', () => {
     cy.visit('http://localhost:5000/apps/protegopdf')
-    cy.get('.app-meta').should('not.contain', 'Downloads')
+    cy.get('.app-meta-entry').should('not.contain', 'Downloads')
   })
 })
 

--- a/scripts/update-app-download-links.js
+++ b/scripts/update-app-download-links.js
@@ -5,7 +5,6 @@ const {getPlatformFromUserAgent, getPlatformLabel} = require('platform-utils')
 
 module.exports = function updateAppDownloadLinks () {
   const links = Array.from(document.querySelectorAll('a.app-download'))
-
   // No downloads links found on the page.
   if (!links.length) return
 
@@ -15,6 +14,7 @@ module.exports = function updateAppDownloadLinks () {
   if (!matches.length) {
     // No downloads found for the detected OS, probably android/ios
     // Hide all links and let them click view all files if wanted
+    links[0].parentNode.style.display = 'none'
   }
 
   links.forEach(link => {

--- a/views/apps/show.html
+++ b/views/apps/show.html
@@ -1,6 +1,6 @@
 <style>
   .site-header, .app-download {
-    background: {{app.goodColorOnWhite}}; 
+    background: {{app.goodColorOnWhite}};
     color: white !important;
   }
 
@@ -24,11 +24,11 @@
   }
 
   .page-section a {
-    color: {{app.goodColorOnWhite}}; 
+    color: {{app.goodColorOnWhite}};
   }
 
   .shell-one-liner {
-    background: {{app.faintColorOnWhite}}; 
+    background: {{app.faintColorOnWhite}};
     color: {{app.goodColorOnWhite}};
   }
 
@@ -91,7 +91,7 @@
 
           {{#if app.latestRelease}}
             {{#if app.latestRelease.assets}}
-              <div class="app-meta-entry">
+              <div class="app-meta-entry app-meta-entry-downloads">
                 <h5>Downloads ({{app.latestRelease.tag_name}})</h5>
 
                 {{#each app.latestRelease.assets}}


### PR DESCRIPTION
Resolves #1221 hiding sidebar "Downloads" section when no downloads available


Co-authored-by:Nhori Lopchan Tamang <nlopchantamang@hubspot.com>
Co-authored-by:Ashley Zeldin <ashley.zeldin@gmail.com>