### PR TITLE
set NODE_ENV when installing to ensure production deps are installed

### DIFF
--- a/script/update-deps.sh
+++ b/script/update-deps.sh
@@ -12,7 +12,7 @@ git clone "https://github.com/electron/electronjs.org" website
 cd website
 git config user.email electron@github.com
 git config user.name electron-bot
-npm install
+NODE_ENV=test npm install
 
 declare -a trusted_deps=("electron-i18n" "electron-apps" "electron-api-historian" "electron-releases")
 


### PR DESCRIPTION
`NODE_ENV` is set to `production` in the website config, which is causing devDependencies to be skipped when `update-electron-dependencies` runs `npm install`. This PR changes the `npm install` command to ensure all deps are installed.