### PR TITLE
chore: manually update electron-releases to 2.80.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3368,9 +3368,9 @@
       "integrity": "sha512-BvZP9q131CgD2OZ/cb6LtL0T2zVb+lw35L6OVVXGHcSL7OoJadukvjPh2UyJfWPldbKS6W2M5O58TIHpYeaD2Q=="
     },
     "electron-releases": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.79.0.tgz",
-      "integrity": "sha512-FCM5h0rsH1+lgVT+gMthzNZ2aOPOIUA2Z/1T37+R18HtvquAtTLw91Afpygh8lct58LjdOKw563sD2X9YX1T6A=="
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.80.0.tgz",
+      "integrity": "sha512-F+t6/3PNb1/si9I3+2CSKvGFnIa1IMt+NBZBoJnob6G1G3zPx99QtPaZs0+I2DDcD+ROlMdLlSvWvsZZsDeEeA=="
     },
     "electron-to-chromium": {
       "version": "1.3.48",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "electron-apps": "^1.4679.0",
     "electron-i18n": "^1.396.0",
     "electron-npm-packages": "3.0.0",
-    "electron-releases": "^2.79.0",
+    "electron-releases": "^2.80.0",
     "electron-userland-reports": "1.6.0",
     "express": "^4.16.2",
     "express-hbs": "^1.0.4",


### PR DESCRIPTION
Similar to https://github.com/electron/electronjs.org/pull/1325, a manual workaround to pick up 3.0.0-beta.13.

This workaround is needed due to https://github.com/electron/electronjs.org/issues/1323