### PR TITLE
chore: manually update electron-releases to 2.80.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3368,9 +3368,9 @@
       "integrity": "sha512-BvZP9q131CgD2OZ/cb6LtL0T2zVb+lw35L6OVVXGHcSL7OoJadukvjPh2UyJfWPldbKS6W2M5O58TIHpYeaD2Q=="
     },
     "electron-releases": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.80.0.tgz",
-      "integrity": "sha512-F+t6/3PNb1/si9I3+2CSKvGFnIa1IMt+NBZBoJnob6G1G3zPx99QtPaZs0+I2DDcD+ROlMdLlSvWvsZZsDeEeA=="
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.82.0.tgz",
+      "integrity": "sha512-L/mqq2q1N+MIGTwCpjpKj2u6UTWcRXhyIJ3jIEcSFx7zE2lrB8JKafSA0Qc2/KFtXT4gNo6HTqpQcWaZFY4Ydg=="
     },
     "electron-to-chromium": {
       "version": "1.3.48",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "electron-apps": "^1.4679.0",
     "electron-i18n": "^1.396.0",
     "electron-npm-packages": "3.0.0",
-    "electron-releases": "^2.80.0",
+    "electron-releases": "^2.82.0",
     "electron-userland-reports": "1.6.0",
     "express": "^4.16.2",
     "express-hbs": "^1.0.4",


### PR DESCRIPTION
Similar to #1325 and #1327, this PR is a manual workaround to pick up the latest version of electron-releases. This time it is to get Electron 3.0.0.

This workaround is needed due to #1323