### PR TITLE
fix: change 404 link in blog post

### DIFF
--- a/data/blog/electron-3-0.md
+++ b/data/blog/electron-3-0.md
@@ -11,7 +11,7 @@ available from [electronjs.org](https://electronjs.org/) and via `npm install el
 
 ## Release Process
 
-As we undertook development of `v3.0.0`, we sought to more empirically define criteria for a stable release by formalizing the feedback progress for progressive beta releases. `v3.0.0` would not have been possible without our [App Feedback Program](https://electronjs.org/docs/tutorial/app-feedback-program) partners, who provided early testing and feedback during the beta cycle. Thanks to Atlassian, Atom, Microsoft Teams, Oculus, OpenFin, Slack, Symphony, VS Code, and other program members for their work. If you'd like to participate in future betas, please mail us at [info@electronjs.org](mailto:info@electronjs.org).
+As we undertook development of `v3.0.0`, we sought to more empirically define criteria for a stable release by formalizing the feedback progress for progressive beta releases. `v3.0.0` would not have been possible without our [App Feedback Program](https://github.com/electron/electron/blob/3-0-x/docs/tutorial/app-feedback-program.md) partners, who provided early testing and feedback during the beta cycle. Thanks to Atlassian, Atom, Microsoft Teams, Oculus, OpenFin, Slack, Symphony, VS Code, and other program members for their work. If you'd like to participate in future betas, please mail us at [info@electronjs.org](mailto:info@electronjs.org).
 
 ## Changes / New Features
 


### PR DESCRIPTION
Change the App Feedback Program link to the 3-0-x branch .md file, since that link should be good in perpetuity