### PR TITLE
manually bump i18n module version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3358,9 +3358,9 @@
       }
     },
     "electron-i18n": {
-      "version": "1.396.0",
-      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-1.396.0.tgz",
-      "integrity": "sha512-V5XIrWFiQJ+ait6hzSS8Qso1n8gds8cHLMN4BpHbPa6ZCVC7PS1xxEUnWzGzyjV5rL4x+Uajp6j63195/WHE9g=="
+      "version": "1.442.0",
+      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-1.442.0.tgz",
+      "integrity": "sha512-aB/z7VPaNUflFGK+m53nY80NR/LYE7QawoxST9vbSBzBUXMsBC+TzSoK/UdQrTcdoMvYcO6dCZIyEt+TEAXsgQ=="
     },
     "electron-npm-packages": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dotenv": "^5.0.0",
     "electron-api-historian": "^1.1.1",
     "electron-apps": "^1.4679.0",
-    "electron-i18n": "^1.396.0",
+    "electron-i18n": "^1.442.0",
     "electron-npm-packages": "3.0.0",
     "electron-releases": "^2.82.0",
     "electron-userland-reports": "1.6.0",


### PR DESCRIPTION
Bring 3.0 to the website manually, because the script that updates trusted deps is still misbehaving: https://github.com/electron/electronjs.org/issues/1323