### PR TITLE
fix: redirect broken faq in search

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -3,5 +3,6 @@
 
 module.exports = {
   '/docs/api/app/': ['/docs/api/old-app-url/', '/docs/api/old-app-url2/'],
-  '/docs/api/webview-tag/': ['/docs/api/web-view-tag/']
+  '/docs/api/webview-tag/': ['/docs/api/web-view-tag/'],
+  '/docs/faq': ['/docs/tutorial/faq/']
 }


### PR DESCRIPTION
Resolves https://github.com/electron/electronjs.org/issues/1308.

This PR adds a redirect for the search result for `FAQ` that directs to `/docs/tutorial/faq`, which is a 404.