### PR TITLE
fix: reset SW cache on language change

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -17,4 +17,5 @@ document.addEventListener('DOMContentLoaded', () => {
   require('./screenshot-thumb-selector')()
   require('./docs-language-toggle')()
   require('./expanding-versions')()
+  require('./reset-lang-cache')()
 })

--- a/scripts/reset-lang-cache.js
+++ b/scripts/reset-lang-cache.js
@@ -1,0 +1,18 @@
+module.exports = () => {
+  const links = document.querySelectorAll('[href^="/languages/"]')
+  for (const link of links) {
+    link.addEventListener('click', (e) => {
+      if (window.caches) {
+        e.preventDefault()
+
+        window.caches.keys()
+          .then((keys) => {
+            for (const key of keys) {
+              window.caches.delete(key)
+            }
+            window.location = link.getAttribute('href')
+          })
+      }
+    })
+  }
+}


### PR DESCRIPTION
My assumption that all content was static based on URL was incorrect, turns out our translations are done based on a cookie.  This PR updates our base JS file (which will be invalidated by the SW on reload) with some logic to wipe the SW cache whenever a locale link is followed.

There is probably a better solution with caching based on that cookie but for now this makes locale switching work again
