### PR TITLE
fix: hide "Electron" at header on screens less 1300px

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -141,4 +141,18 @@ describe('electronjs.org', () => {
       cy.get('.jumbotron-lead').contains('Создавайте кросс-платформенные приложения при помощи JavaScript, HTML и CSS')
     })
   })
+
+  describe('header', () => {
+    it('"Electron" hides on small displays (less 1300px)', () => {
+      cy.visit(localhost)
+      cy.get('.site-header-logo').not('.vertical-middle')
+    })
+
+    it('"Electron" contains on displays more 1300px', () => {
+      // Set display resolution to 1600x900
+      cy.viewport(1600, 900)
+      cy.visit(localhost)
+      cy.get('.site-header-logo').contains('Electron')
+    })
+  })
 })

--- a/styles/_home.scss
+++ b/styles/_home.scss
@@ -203,3 +203,9 @@ $app-list-icon-size: 48px;
   background-color: #FAFAFA;
   box-shadow: 0 25px 30px -18px rgba(0, 0, 0, 0.28);
 }
+
+@media screen and (max-width: 1300px) {
+  svg.vertical-middle {
+    display: none;
+  }
+}


### PR DESCRIPTION
Not fix but start for #1305.