### PR TITLE
Display install commands for apps on npmjs

### DIFF
--- a/views/apps/show.html
+++ b/views/apps/show.html
@@ -116,6 +116,13 @@
               <span class="shell-one-liner" style="margin-top: 4px; display: block;">sudo snap install {{app.snapcraftName}}</span>
             </div>
           {{/if}}
+          
+          {{#if app.npmPackageName}}
+            <div class="npm-only app-meta-entry">
+              <h5>npm</h5>
+              <span class="shell-one-liner" style="margin-top: 4px; display: block;">npm install -g {{app.npmPackageName}}</span>
+            </div>
+          {{/if}}
 
           {{#if app.keywords}}
             <div class="app-meta-entry">


### PR DESCRIPTION
Display install commands for apps on npmjs.

Fixes #1457 

<img width="1200" alt="screen shot 2018-10-26 at 9 12 46 pm" src="https://user-images.githubusercontent.com/17772508/47599128-6ccaff00-d964-11e8-9278-7a5461935a2d.png">
