### PR TITLE
fix: memory leak on feed construction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,7 +1033,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2690,7 +2689,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -5576,6 +5575,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-memoize": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
+      "integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g=="
+    },
     "fault": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
@@ -5839,8 +5843,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5858,13 +5861,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5877,18 +5878,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5991,8 +5989,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6002,7 +5999,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6015,20 +6011,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6045,7 +6038,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6118,8 +6110,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6129,7 +6120,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6205,8 +6195,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6236,7 +6225,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6254,7 +6242,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6293,13 +6280,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8741,8 +8726,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -8937,7 +8921,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -9367,7 +9351,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "express": "^4.16.2",
     "express-hbs": "^1.0.4",
     "express-request-language": "^1.1.15",
+    "fast-memoize": "^2.5.1",
     "feed": "^2.0.1",
     "flat": "^4.1.0",
     "got": "^9.3.0",

--- a/routes/feed/blog.js
+++ b/routes/feed/blog.js
@@ -1,21 +1,7 @@
-const feed = require('./mainFeed')
-const description = require('description')
+const { setupFeed } = require('./mainFeed')
 
-// Feed for Blog
 module.exports = function feedHandler (req, res, next) {
-  req.context.posts.forEach(function (post) {
-    feed.addItem({
-      id: `https://electronjs.org${post.href}`,
-      title: post.title,
-      content: post.content,
-      description: description({ content: post.content, endWith: '[...]', limit: 200 }),
-      link: `https://electronjs.org${post.href}`,
-      date: new Date(post.date),
-      published: new Date(post.date),
-      author: post.author,
-      image: post.image || 'https://electronjs.org/images/opengraph.png'
-    })
-  })
+  const feed = setupFeed('blog', req.context.posts)
 
   if (req.path === '/blog.xml') {
     res.set('content-type', 'text/xml')

--- a/routes/feed/blog.js
+++ b/routes/feed/blog.js
@@ -1,7 +1,9 @@
 const { setupFeed } = require('./mainFeed')
+const memoize = require('fast-memoize')
 
 module.exports = function feedHandler (req, res, next) {
-  const feed = setupFeed('blog', req.context.posts)
+  const cachedSetupFeed = memoize(setupFeed)
+  const feed = cachedSetupFeed('blog', req.context.posts)
 
   if (req.path === '/blog.xml') {
     res.set('content-type', 'text/xml')

--- a/routes/feed/blog.js
+++ b/routes/feed/blog.js
@@ -1,9 +1,7 @@
 const { setupFeed } = require('./mainFeed')
-const memoize = require('fast-memoize')
 
 module.exports = function feedHandler (req, res, next) {
-  const cachedSetupFeed = memoize(setupFeed)
-  const feed = cachedSetupFeed('blog', req.context.posts)
+  const feed = setupFeed('blog', req.context.posts)
 
   if (req.path === '/blog.xml') {
     res.set('content-type', 'text/xml')

--- a/routes/feed/mainFeed.js
+++ b/routes/feed/mainFeed.js
@@ -1,12 +1,13 @@
 const Feed = require('feed').Feed
 const description = require('description')
+const memoize = require('fast-memoize')
 
 const types = {
   blog: 'blog',
   releases: 'releases'
 }
 
-module.exports.setupFeed = (type, items) => {
+module.exports.setupFeed = memoize((type, items) => {
   let feed = new Feed({
     title: 'Electron',
     description:
@@ -54,4 +55,4 @@ module.exports.setupFeed = (type, items) => {
   }
 
   return feed
-}
+})

--- a/routes/feed/mainFeed.js
+++ b/routes/feed/mainFeed.js
@@ -1,16 +1,51 @@
 const Feed = require('feed').Feed
+const description = require('description')
 
-module.exports = new Feed({
-  title: 'Electron',
-  description:
-    'Build cross platform desktop apps with JavaScript, HTML, and CSS.',
-  id: 'https://electronjs.org/',
-  link: 'https://electronjs.org/',
-  generator: 'Electron website',
-  feedLinks: {
-    json: 'https://electronjs.org/releases.json',
-    atom: 'https://electronjs.org/releases.xml',
-    json1: 'https://electronjs.org/blog.json',
-    atom1: 'https://electronjs.org/blog.xml'
+const types = {
+  blog: 'blog',
+  releases: 'releases'
+}
+
+module.exports.setupFeed = (type, items) => {
+  let feed = new Feed({
+    title: 'Electron',
+    description:
+      'Build cross platform desktop apps with JavaScript, HTML, and CSS.',
+    id: 'https://electronjs.org/',
+    link: 'https://electronjs.org/',
+    generator: 'Electron website',
+    feedLinks: {
+      json: 'https://electronjs.org/releases.json',
+      atom: 'https://electronjs.org/releases.xml',
+      json1: 'https://electronjs.org/blog.json',
+      atom1: 'https://electronjs.org/blog.xml'
+    }
+  })
+
+  if (type === types.releases) {
+    items.forEach(release => {
+      feed.addItem({
+        id: `https://electronjs.org/releases#${release.version}`,
+        date: new Date(release.created_at),
+        link: release.html_url,
+        content: release.body_html
+      })
+    })
+  } else if (types === types.blog) {
+    items.forEach(post => {
+      feed.addItem({
+        id: `https://electronjs.org${post.href}`,
+        title: post.title,
+        content: post.content,
+        description: description({ content: post.content, endWith: '[...]', limit: 200 }),
+        link: `https://electronjs.org${post.href}`,
+        date: new Date(post.date),
+        published: new Date(post.date),
+        author: post.author,
+        image: post.image || 'https://electronjs.org/images/opengraph.png'
+      })
+    })
   }
-})
+
+  return feed
+}

--- a/routes/feed/mainFeed.js
+++ b/routes/feed/mainFeed.js
@@ -22,29 +22,35 @@ module.exports.setupFeed = (type, items) => {
     }
   })
 
-  if (type === types.releases) {
-    items.forEach(release => {
-      feed.addItem({
-        id: `https://electronjs.org/releases#${release.version}`,
-        date: new Date(release.created_at),
-        link: release.html_url,
-        content: release.body_html
+  switch (type) {
+    case types.releases:
+      items.forEach(release => {
+        feed.addItem({
+          id: `https://electronjs.org/releases#${release.version}`,
+          date: new Date(release.created_at),
+          link: release.html_url,
+          content: release.body_html
+        })
       })
-    })
-  } else if (types === types.blog) {
-    items.forEach(post => {
-      feed.addItem({
-        id: `https://electronjs.org${post.href}`,
-        title: post.title,
-        content: post.content,
-        description: description({ content: post.content, endWith: '[...]', limit: 200 }),
-        link: `https://electronjs.org${post.href}`,
-        date: new Date(post.date),
-        published: new Date(post.date),
-        author: post.author,
-        image: post.image || 'https://electronjs.org/images/opengraph.png'
+      break
+    case types.blog:
+      items.forEach(post => {
+        feed.addItem({
+          id: `https://electronjs.org${post.href}`,
+          title: post.title,
+          content: post.content,
+          description: description({ content: post.content, endWith: '[...]', limit: 200 }),
+          link: `https://electronjs.org${post.href}`,
+          date: new Date(post.date),
+          published: new Date(post.date),
+          author: post.author,
+          image: post.image || 'https://electronjs.org/images/opengraph.png'
+        })
       })
-    })
+      break
+    default:
+      console.log(type === types.releases)
+      throw new Error('Invalid rss feed type')
   }
 
   return feed

--- a/routes/feed/releases.js
+++ b/routes/feed/releases.js
@@ -1,9 +1,7 @@
 const { setupFeed } = require('./mainFeed')
-const memoize = require('fast-memoize')
 
 module.exports = function feedHandler (req, res, next) {
-  const cachedSetupFeed = memoize(setupFeed)
-  const feed = cachedSetupFeed('releases', req.context.releases)
+  const feed = setupFeed('releases', req.context.releases)
 
   if (req.path === '/releases.xml') {
     res.set('content-type', 'text/xml')

--- a/routes/feed/releases.js
+++ b/routes/feed/releases.js
@@ -1,7 +1,9 @@
 const { setupFeed } = require('./mainFeed')
+const memoize = require('fast-memoize')
 
 module.exports = function feedHandler (req, res, next) {
-  const feed = setupFeed('releases', req.context.releases)
+  const cachedSetupFeed = memoize(setupFeed)
+  const feed = cachedSetupFeed('releases', req.context.releases)
 
   if (req.path === '/releases.xml') {
     res.set('content-type', 'text/xml')

--- a/routes/feed/releases.js
+++ b/routes/feed/releases.js
@@ -1,14 +1,7 @@
-const feed = require('./mainFeed')
+const { setupFeed } = require('./mainFeed')
 
 module.exports = function feedHandler (req, res, next) {
-  req.context.releases.forEach(function (releases) {
-    feed.addItem({
-      id: `https://electronjs.org/releases#${releases.version}`,
-      date: new Date(releases.created_at),
-      link: releases.html_url,
-      content: releases.body_html
-    })
-  })
+  const feed = setupFeed('releases', req.context.releases)
 
   if (req.path === '/releases.xml') {
     res.set('content-type', 'text/xml')


### PR DESCRIPTION
The feed was previously abstracted out but in such a way that for every request to the release endpoint, all of the releases were added to the feed again. This lead to memory leaks and errors, as seen here:

<img width="488" alt="screen shot 2018-11-03 at 7 14 46 pm" src="https://user-images.githubusercontent.com/2036040/47959741-f011d380-dfa8-11e8-8c49-0d22fc25694d.png">

This abstracts out feed population to mitigate those errors.

/cc @MarshallOfSound 