### PR TITLE
fix: skip waiting when updating SW for instant results

### DIFF
--- a/scripts/service-worker.tmpl.js
+++ b/scripts/service-worker.tmpl.js
@@ -3,6 +3,10 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/3.6.1/workbox-sw.js')
 importScripts('/scripts/precache.{PRE_HASH}.js')
 
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
 if (typeof workbox !== 'undefined') {
   workbox.precaching.precacheAndRoute(self.precache)
   // Fetch JS from network, fallback to cache


### PR DESCRIPTION
Refs: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting