### PR TITLE
chore: remove old npm package search link

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -58,10 +58,6 @@ community:
       <a href='https://discuss.atom.io/c/electron'>Discuss</a>,
       or visiting
       <a href='https://stackoverflow.com/questions/tagged/electron'>Stack Overflow</a>."
-    packages:
-      "<a href='/search/npmPackages'><b>Find useful npm packages</b></a>
-      on the
-      <a href='/search/npmPackages'>package search page</a>."
     bugs:
       "<a href='https://github.com/electron/electron/issues'><b>Report bugs</b></a>
       by opening issues on the

--- a/package-lock.json
+++ b/package-lock.json
@@ -2276,7 +2276,7 @@
         },
         "yargs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
           "dev": true,
           "requires": {
@@ -2961,7 +2961,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
         }
       }
@@ -4076,11 +4076,6 @@
       "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-1.908.0.tgz",
       "integrity": "sha512-5Y84rP+4Tqx1/jlOdZgBx9f+x8+70+Mfiom4B1XBzzWUsvkAoeUUiKiMJFHIgazyYk3x4ia0IHfaE+FPRpyJIw=="
     },
-    "electron-npm-packages": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/electron-npm-packages/-/electron-npm-packages-4.1.2.tgz",
-      "integrity": "sha512-qhpbXoECwM68Ys2J9FkAGsJdBYbtojKZ4ENjZIGqrJimhpz2H/ktxeWQcBjDejgNuV0oaYvOMX7JjSIWTBcSZg=="
-    },
     "electron-releases": {
       "version": "3.37.0",
       "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-3.37.0.tgz",
@@ -4568,7 +4563,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -5044,13 +5039,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -5393,8 +5388,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5412,13 +5406,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5431,18 +5423,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5545,8 +5534,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5556,7 +5544,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5569,20 +5556,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5599,7 +5583,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5672,8 +5655,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5683,7 +5665,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5759,8 +5740,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5790,7 +5770,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5808,7 +5787,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5847,13 +5825,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -6392,7 +6368,7 @@
       "dependencies": {
         "mkdirp": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
         },
         "nopt": {
@@ -7158,7 +7134,7 @@
       "dependencies": {
         "events": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
           "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         }
       }
@@ -8068,7 +8044,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -9522,7 +9498,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -9715,7 +9691,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "electron-api-historian": "^1.1.1",
     "electron-apps": "^1.5913.0",
     "electron-i18n": "^1.908.0",
-    "electron-npm-packages": "4.1.2",
     "electron-releases": "^3.37.0",
     "electron-userland-reports": "1.6.0",
     "express": "^4.16.2",

--- a/views/community.html
+++ b/views/community.html
@@ -12,7 +12,6 @@
     <p class="lead mb-4">📣 {{{localized.community.channels.updates}}}</p>
     <p class="lead mb-4">🙋 {{{localized.community.channels.help}}}</p>
     <p class="lead mb-4">🌍 {{{localized.community.channels.localized_docs}}}</p>
-    <p class="lead mb-4">📦 {{{localized.community.channels.packages}}}</p>
     <p class="lead mb-4">🐞 {{{localized.community.channels.bugs}}}</p>
     <p class="lead mb-4">💡 {{{localized.community.channels.feature_requests}}}</p>
     <p class="lead mb-4">⚖️ {{{localized.community.channels.code_of_conduct}}}</p>
@@ -25,7 +24,7 @@
     <h2 id="language-communities">{{localized.community.language_communities.title}}</h2>
 
     <p>{{{localized.community.language_communities.description}}}</p>
-    
+
     <ul>
       <li><a href="https://telegram.me/electron_ru" rel="nofollow">electron-ru</a> <em>(Russian)</em></li>
       <li><a href="https://electron-br.slack.com" rel="nofollow">electron-br</a> <em>(Brazilian Portuguese)</em></li>
@@ -37,7 +36,7 @@
     </ul>
   </div>
 
-  <div class="container-narrow">    
+  <div class="container-narrow">
     <h2 id="tools">{{localized.community.tools}}</h2>
     <table class="table table-ruled table-full-width table-with-spacious-first-column mb-7">
       {{#each items}}


### PR DESCRIPTION
This functionality was removed in 0ef9164dd77958db17e071e71bd5d40dc67d3c4b