### PR TITLE
chore: Add a link to the license

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -9,6 +9,7 @@ nav:
   docs: Docs
   donors: Donors
   languages: Languages
+  license: License
   releases: Releases
   search: Search
   userland: Userland

--- a/test/index.js
+++ b/test/index.js
@@ -77,6 +77,12 @@ describe('electronjs.org', () => {
       $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md"]')
         .text().should.eq('Code of Conduct')
     })
+
+    test('displays License link in the footer', async () => {
+      const $ = await get('/')
+      $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/LICENSE"]')
+        .text().should.eq('License')
+    })
   })
 
   describe('apps', () => {

--- a/views/partials/footer.html
+++ b/views/partials/footer.html
@@ -8,6 +8,7 @@
       <a class="footer-nav-item" href="/apps">{{localized.nav.apps}}</a>
       <a class="footer-nav-item" href="/releases/stable">{{localized.nav.releases}}</a>
       <a class="footer-nav-item" href="https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md">{{localized.nav.code_of_conduct}}</a>
+      <a class="footer-nav-item" href="https://github.com/electron/electron/tree/master/LICENSE">{{localized.nav.license}}</a>
       <a class="footer-nav-item" href="/languages">{{localized.nav.languages}}</a>
       <a class="footer-nav-item" href="/contact">{{localized.nav.contact}}</a>
     </nav>


### PR DESCRIPTION
This merely adds a link to the [LICENSE](https://github.com/electron/electron/tree/master/LICENSE). A friend of the project looked for it and couldn't find it – and we should really have it on the website.