### PR TITLE
docs: Adding Microsoft Teams app to the featured apps list

### DIFF
--- a/lib/apps.js
+++ b/lib/apps.js
@@ -22,7 +22,8 @@ const featured = [
   'svgsus',
   'visual-studio-code',
   'webtorrent',
-  'wordpress-com'
+  'wordpress-com',
+  'microsoft-teams'
 ]
 
 const apps = require('electron-apps')

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,7 @@ describe('electronjs.org', () => {
       const $ = await get('/')
       $('header').should.have.class('site-header')
       $('p.jumbotron-lead').should.contain('Build cross platform desktop apps')
-      $('.featured-app').length.should.equal(24)
+      $('.featured-app').length.should.equal(25)
       $('head > title').text().should.match(/^Electron/)
     })
 


### PR DESCRIPTION
Adding Microsoft Teams app to the featured app section of the electronjs.org home page.