### PR TITLE
chore: use 'compressed' output style for CSS

### DIFF
--- a/script/precompile-assets.js
+++ b/script/precompile-assets.js
@@ -73,7 +73,8 @@ function precompileCss () {
       file: PATHS.cssEntry,
       includePaths: [
         PATHS.nodeModules
-      ]
+      ],
+      outputStyle: 'compressed'
     }, async function onSassCompiled (err, result) {
       if (err) {
         return reject(err)


### PR DESCRIPTION
Changes precompiled CSS bundle size from 141K to 106K (~24% savings)