### PR TITLE
fix: updated instantsearch to v3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
+    "algoliasearch": "^3.32.0",
     "awesome-electron": "2.6.0",
     "babelify": "^10.0.0",
     "brfs": "^2.0.2",
@@ -59,7 +60,7 @@
     "helmet": "^3.16.0",
     "http-proxy-middleware": "^0.19.1",
     "hubdown": "^2.1.0",
-    "instantsearch.js": "^2.10.4",
+    "instantsearch.js": "^3.1.1",
     "lil-env-thing": "^1.0.0",
     "lobars": "^1.2.0",
     "locale-code": "^2.0.2",


### PR DESCRIPTION
@HashimotoYT , I have updated instantsearch to v3.1.1 and I only needed to change `/scripts/search.js` file(and not any styles) but the margin between github icon and search bar is decreased(which I don't understand why :confused: ). Could you please guide me to fix it :smiley: .
I've attached the appropriate images.


![Image before applying the changes](https://user-images.githubusercontent.com/37845584/54488120-fd7a8b00-48c3-11e9-9a3f-23143f540c8d.jpg)


![Image after applying the changes](https://user-images.githubusercontent.com/37845584/54488105-d754eb00-48c3-11e9-9682-b77ae523ffe7.jpg)
