### PR TITLE
feat: Add link to security document

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -4,6 +4,7 @@ nav:
   apps: Apps
   blog: Blog
   code_of_conduct: Code of Conduct
+  security: Security
   community: Community
   contact: Contact
   docs: Docs

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,12 @@ describe('electronjs.org', () => {
         .text().should.eq('Code of Conduct')
     })
 
+    test('displays Security link in the footer', async () => {
+      const $ = await get('/')
+      $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/SECURITY.md"]')
+        .text().should.eq('Security')
+    })
+
     test('displays License link in the footer', async () => {
       const $ = await get('/')
       $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/LICENSE"]')

--- a/views/partials/footer.html
+++ b/views/partials/footer.html
@@ -9,6 +9,7 @@
       <a class="footer-nav-item" href="/releases/stable">{{localized.nav.releases}}</a>
       <a class="footer-nav-item" href="https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md">{{localized.nav.code_of_conduct}}</a>
       <a class="footer-nav-item" href="https://github.com/electron/electron/tree/master/LICENSE">{{localized.nav.license}}</a>
+      <a class="footer-nav-item" href="https://github.com/electron/electron/tree/master/SECURITY.md">{{localized.nav.security}}</a>
       <a class="footer-nav-item" href="/languages">{{localized.nav.languages}}</a>
       <a class="footer-nav-item" href="/contact">{{localized.nav.contact}}</a>
     </nav>


### PR DESCRIPTION
As discussed in the meeting we just had, this PR adds a link to the security document in `electron/electron`.