### PR TITLE
ci: Update Travis to use Node 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "11"
 notifications:
   email: false
 before_install:


### PR DESCRIPTION
We use Node 10 on prod, why not use 11 on CI.