### PR TITLE
feat: make 'security' slightly easier to find on the comunity page

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -72,6 +72,10 @@ community:
       <a href='https://discuss.atom.io/c/electron'>Discuss</a>,
       or visiting
       <a href='https://stackoverflow.com/questions/tagged/electron'>Stack Overflow</a>."
+    security:
+      "<a href='mailto:security@electronjs.org'><b>Report security issues</b></a>
+      by emailing
+      <a href='mailto:security@electronjs.org'>security@electronjs.org</a>."
     bugs:
       "<a href='https://github.com/electron/electron/issues'><b>Report bugs</b></a>
       by opening issues on the
@@ -86,10 +90,6 @@ community:
       "<a href='mailto:coc@electronjs.org'><b>Report Code of Conduct violations</b></a>
       by emailing
       <a href='mailto:coc@electronjs.org'>coc@electronjs.org</a>."
-    security:
-      "<a href='mailto:security@electronjs.org'><b>Disclose security issues</b></a>
-      by emailing
-      <a href='mailto:security@electronjs.org'>security@electronjs.org</a>."
     donations:
       "<a href='donors'><b>Donate</b></a>
       on our

--- a/views/community.html
+++ b/views/community.html
@@ -12,10 +12,10 @@
     <p class="lead mb-4">📣 {{{localized.community.channels.updates}}}</p>
     <p class="lead mb-4">🙋 {{{localized.community.channels.help}}}</p>
     <p class="lead mb-4">🌍 {{{localized.community.channels.localized_docs}}}</p>
+    <p class="lead mb-4">🔒 {{{localized.community.channels.security}}}</p>
     <p class="lead mb-4">🐞 {{{localized.community.channels.bugs}}}</p>
     <p class="lead mb-4">💡 {{{localized.community.channels.feature_requests}}}</p>
     <p class="lead mb-4">⚖️ {{{localized.community.channels.code_of_conduct}}}</p>
-    <p class="lead mb-4">🙊 {{{localized.community.channels.security}}}</p>
     <p class="lead mb-4">💰 {{{localized.community.channels.donations}}}</p>
     <p class="lead mb-4">❓ {{{localized.community.channels.other}}}</p>
   </div>


### PR DESCRIPTION
Tweak to the community page to make "report a security issue" easier to find:
 * move it higher in the list
 * replace the monkey emoji with a lock, since if you're looking for security it's visually easier to make the connection to a lock icon than a monkey icon