### PR TITLE
fix: don't show filter app bar when we on mobile

### DIFF
--- a/public/styles/_app.scss
+++ b/public/styles/_app.scss
@@ -268,6 +268,12 @@
   margin: 0;
 }
 
+@media (max-width: 700px) {
+  .categories-filter {
+    display: none !important;
+  }
+}
+
 .filter-item {
   padding: 4px 8px;
 }
@@ -297,9 +303,9 @@
   margin-left: -12px;
 }
 .mobile-hidden {
-  display: none;
+  display: none !important;
   @include breakpoint(md) {
-    display: block;
+    display: block !important;
   }
 }
 

--- a/views/apps/index.html
+++ b/views/apps/index.html
@@ -31,7 +31,7 @@
       </div>
       <!-- ./categories-filter -->
 
-      <div class="col-xs-12 col-md-9 container-lg mx-4" id="apps">
+      <div class="col-xs-12 col-md-9 container-lg" id="apps">
 
         <ul class="mb-4 filterable-list app-list">
           {{#each apps}}


### PR DESCRIPTION
| `master` | `this branch` |
| --- | --- |
| ![prev](https://user-images.githubusercontent.com/24681191/55829313-123eed00-5b17-11e9-8cef-96d10dafb6f4.png) | ![localhost_5000_apps](https://user-images.githubusercontent.com/24681191/55829321-166b0a80-5b17-11e9-86ef-d0c4f16a5413.png) |

