### PR TITLE
ci: disable e2e integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
 # package-lock.json was introduced in npm@5
   - '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
 script:
-  - npm test && npm run integration
+  - npm test # && npm run integration


### PR DESCRIPTION
This PR disables e2e Cypress integrations tests due to this error:

> You've exceeded the limit of private test recordings under your free plan this month. The limit is 500 private test recordings.
> To continue recording tests this month you must upgrade your account. Please visit your billing to upgrade to another billing plan.

For stop block automatic PR's from Dependabot, I'm planning to disable this for some investigation.