### PR TITLE
chore(deps): bump electron-i18n@1.1309.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,9 +4731,9 @@
       }
     },
     "electron-i18n": {
-      "version": "1.1308.0",
-      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-1.1308.0.tgz",
-      "integrity": "sha512-Bf/hYgiUFvtMhPL55PK6Py/0Gw+O3O1xIR0HGxvNnRwZO24p1aWbV8OSSNCyYI5OH67350h/bFfZZflSCQsUtA=="
+      "version": "1.1309.0",
+      "resolved": "https://registry.npmjs.org/electron-i18n/-/electron-i18n-1.1309.0.tgz",
+      "integrity": "sha512-hyCNbV4ptTI8GVqalU+2zbChmrYu3x2X6oEgT+28rN05qm7JL8/I1WHkRqW8GAN+Cdw0Dbda2yFazSxwKWuB/A=="
     },
     "electron-markdown": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dotenv": "^7.0.0",
     "electron-api-historian": "^1.1.1",
     "electron-apps": "^1.7415.0",
-    "electron-i18n": "^1.1308.0",
+    "electron-i18n": "^1.1309.0",
     "electron-markdown": "^0.5.0",
     "electron-releases": "^3.100.0",
     "electron-userland-reports": "1.6.0",


### PR DESCRIPTION
Fixes issues with Electron release timeline document.