### PR TITLE
feat: add Electron hosted headers redirect

### DIFF
--- a/routes/headers.js
+++ b/routes/headers.js
@@ -1,10 +1,8 @@
-const fs = require('fs-extra');
-
 const DIST_URL = 'https://gh-contractor-zcbenz.s3.amazonaws.com/atom-shell/dist'
 
 module.exports = (req, res, next) => {
   console.log(req.params[0])
   const url = req.params[0]
   if (url === []) return next()
-  return res.redirect(`${DIST_URL}/${url}`);
+  return res.redirect(`${DIST_URL}/${url}`)
 }

--- a/routes/headers.js
+++ b/routes/headers.js
@@ -1,7 +1,6 @@
 const DIST_URL = 'https://gh-contractor-zcbenz.s3.amazonaws.com/atom-shell/dist'
 
 module.exports = (req, res, next) => {
-  console.log(req.params[0])
   const url = req.params[0]
   if (url === []) return next()
   return res.redirect(`${DIST_URL}/${url}`)

--- a/routes/headers.js
+++ b/routes/headers.js
@@ -1,0 +1,10 @@
+const fs = require('fs-extra');
+
+const DIST_URL = 'https://gh-contractor-zcbenz.s3.amazonaws.com/atom-shell/dist'
+
+module.exports = (req, res, next) => {
+  console.log(req.params[0])
+  const url = req.params[0]
+  if (url === []) return next()
+  return res.redirect(`${DIST_URL}/${url}`);
+}

--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ app.use(requestLanguage({
   languages: Object.keys(i18n.locales),
   cookie: {
     name: 'language',
-    options: {maxAge: 30 * 24 * 60 * 60 * 1000},
+    options: { maxAge: 30 * 24 * 60 * 60 * 1000 },
     url: '/languages/{language}'
   }
 }))

--- a/server.js
+++ b/server.js
@@ -111,6 +111,7 @@ app.get('/userland', routes.userland.index)
 app.get('/userland/*', routes.userland.show)
 app.use('/crowdin', routes.languages.proxy)
 app.use('/donors', routes.donors)
+app.use('/headers/*', routes.headers)
 app.get('/search/:searchIn*?*', (req, res) => res.redirect(req.query.q ? `/?query=${req.query.q}` : `/`))
 
 // Generic 404 handler

--- a/test/index.js
+++ b/test/index.js
@@ -655,6 +655,18 @@ describe('electronjs.org', () => {
       res.headers['content-type'].should.equal('application/javascript; charset=UTF-8')
     })
 
+    describe('node headers', () => {
+      it('redirects valid to S3 Bucket', async () => {
+        let res = await supertest(app).get(`/headers/v3.1.6/iojs-3.1.6.tgz.tz`)
+        res.statusCode.should.equal(302)
+      })
+
+      it('show 404 to invalid', async () => {
+        let res = await supertest(app).get(`/headers`)
+        res.statusCode.should.equal(404)
+      })
+    })
+
     describe('search redirects', () => {
       it('redirect /search/package to home page search', async () => {
         const res = await supertest(app).get('/search/npmPackages?q=@siberianmh/cosmos')


### PR DESCRIPTION
This PR creates a URL for downloading rebuilding assets on electron website.

## Questions:

- What we should do with the previous two URLs. (atom.io/download/{atom-shell, electron})
  - remove? redirect?

## Verification Process:

- [ ] Update URL in electron-rebuild and verify all tests pass (locally and on CI)
- [ ] Update URL in GH Desktop and verify nothing was broken (If nobody is against. I think we anyway should update his, also this have CI on three platforms.)

---

Also, I want to say thanks @MarshallOfSound for creating this issue, about doing this I thought sometimes.

Fixes #2519