### PR TITLE
chore: update electron-api-historian to v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4706,9 +4706,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-api-historian": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/electron-api-historian/-/electron-api-historian-1.1.1.tgz",
-      "integrity": "sha512-t7Rce45VYDfv/5NBeiqnWySPCJwdz+olD6lQ6UdoOsZIm+ocsk0ttHmCNqsx57BxrH12SY8M1hFS00keQ3sIMA=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/electron-api-historian/-/electron-api-historian-1.1.2.tgz",
+      "integrity": "sha512-27eoMgmLr5w9WkpfZQ5li73/TsMEM+xsb2d8EqjtSXHqcafq9BgFtxnBKkFGuVRqdCzS+x9R5du+pPNYkRV01w=="
     },
     "electron-apps": {
       "version": "1.7425.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "crowdin-editor-language-codes": "^1.0.0",
     "description": "0.0.4",
     "dotenv": "^8.0.0",
-    "electron-api-historian": "^1.1.1",
+    "electron-api-historian": "^1.1.2",
     "electron-apps": "^1.7425.0",
     "electron-i18n": "^1.1331.0",
     "electron-markdown": "^0.5.0",


### PR DESCRIPTION
Fixes issue with bad history on https://electronjs.org/docs/api/net-log/history and other new modules.