### PR TITLE
fix: horizontal text overflow on mobile devices

### DIFF
--- a/public/styles/hljs/overrides.scss
+++ b/public/styles/hljs/overrides.scss
@@ -1,5 +1,4 @@
 pre {
-  overflow: visible !important;
   position: relative !important;
   .btn-clipboard {
     outline: 0 !important;


### PR DESCRIPTION
This fixes issue #2599 where the text on the preformatted block overflows on mobile devices.