### PR TITLE
fix: add overflow-auto for homepage code block

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -190,7 +190,7 @@
   </h3>
   <p>{{{localized.quick_start.description}}}</p>
 
-  <figure class="highlight highlight-dark text-left my-6">
+  <figure class="highlight highlight-dark text-left my-6 overflow-auto">
 <pre><code><span class="c1"># {{{localized.quick_start.clone}}}</span>
 $ git clone https://github.com/electron/electron-quick-start
 


### PR DESCRIPTION
## Why not `white-space: pre-wrap`.

> Fixup from twitter.

Because:

![oy see this prewrap](https://user-images.githubusercontent.com/24681191/59117487-8a2e6580-8956-11e9-9a45-ff07f59ac37b.png)

## Why not `white-space: pre-line`.

> Fixup from other pr

Because:

![it's preline](https://user-images.githubusercontent.com/24681191/59117535-a500da00-8956-11e9-95fb-01bab0fc1717.png)

## Why this?

Because I'm don't want to fix the bug for mobiles and create a new bug for desktops. I know this issue, I'm the creator of this issue. It's global file what uses not only on the homepage when I'm found the best option to fix this I fix this globally, but this fixes this strange global message.

Life is Strange 2

Closes #2629 
Closes #2599 
Closes #2600
