### PR TITLE
feat: add 'Launch in Fiddle' button to code blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cypress/videos/*
 /precompiled/
 .nyc_output
 coverage
+.DS_Store

--- a/data/locale.yml
+++ b/data/locale.yml
@@ -262,6 +262,10 @@ clipboard:
   copy_to_clipboard: Copy to Clipboard
   copied: Copied
 
+fiddle_launch_button:
+  launch: Launch
+  launch_in_fiddle: Launch in Fiddle
+
 or: or
 
 pages:

--- a/public/styles/hljs/overrides.scss
+++ b/public/styles/hljs/overrides.scss
@@ -1,17 +1,28 @@
 pre {
   overflow: visible !important;
   position: relative !important;
-  .btn-clipboard {
-    outline: 0 !important;
-    position: absolute !important;
-    top: 5px !important;
-    right: 5px !important;
-    padding: .25rem .5rem !important;
+  .btn-group {
+    border: 1px #e5e5e5 solid !important;
+    border-radius: 3px !important;
     font-size: 14px !important;
     font-weight: 500 !important;
-    border: 1px #e5e5e5 solid !important;
+    position: absolute !important;
+    right: 5px !important;
+    top: 5px !important;
+
+    button {
+      border-right: 1px #e5e5e5 solid !important;
+    }
+    button:last-child {
+      border-right: none !important;
+    }
+  }
+
+  .btn-launch, .btn-clipboard {
     background-color: #f8f8f8 !important;
-    border-radius: 3px !important;
+    border: none !important;
+    outline: 0 !important;
+    padding: .25rem .5rem !important;
     transition: 0.2s !important;
 
     &:hover {

--- a/scripts/add-code-block-buttons.js
+++ b/scripts/add-code-block-buttons.js
@@ -46,7 +46,19 @@ module.exports = function copyCodeToClipBoard () {
       e.target.blur()
     })
     button.addEventListener('click', e => {
+      // used to detect whether fiddle is installed
+      let windowLostFocus = false
+      const focusLostListener = () => { windowLostFocus = true }
+      window.addEventListener('blur', focusLostListener)
+
+      // try to open fiddle
       window.location.href = e.target.dataset.fiddleUrl
+
+      // redirect to install page if nothing happened
+      setTimeout(() => {
+        window.removeEventListener('blur', focusLostListener)
+        if (!windowLostFocus) window.location.href = '/fiddle'
+      }, 500)
     })
   })
 

--- a/scripts/add-code-block-buttons.js
+++ b/scripts/add-code-block-buttons.js
@@ -16,6 +16,7 @@ module.exports = function copyCodeToClipBoard () {
     const id = `_${Math.random().toString(36).substr(5)}`
     code.id = id
 
+    // add button group to code block
     const buttonGroup = document.createElement('div')
     buttonGroup.classList.add('btn-group', 'border', 'float-left')
     code.parentElement.appendChild(buttonGroup)
@@ -30,6 +31,7 @@ module.exports = function copyCodeToClipBoard () {
       buttonGroup.appendChild(launchButton)
     }
 
+    // add clipboard button
     const copyButton = document.createElement('button')
     copyButton.classList.add('btn-clipboard', 'tooltipped', 'tooltipped-n', 'float-left')
     copyButton.setAttribute('aria-label', window.localized.clipboard.copy_to_clipboard)
@@ -38,6 +40,7 @@ module.exports = function copyCodeToClipBoard () {
     buttonGroup.appendChild(copyButton)
   })
 
+  // launch button listeners
   document.querySelectorAll('.btn-launch').forEach(button => {
     button.addEventListener('mouseout', e => {
       e.target.blur()
@@ -47,6 +50,7 @@ module.exports = function copyCodeToClipBoard () {
     })
   })
 
+  // clipboard button listeners
   document.querySelectorAll('.btn-clipboard').forEach(button => {
     button.addEventListener('mouseout', e => {
       e.target.setAttribute('aria-label', window.localized.clipboard.copy_to_clipboard)

--- a/scripts/add-code-block-buttons.js
+++ b/scripts/add-code-block-buttons.js
@@ -46,19 +46,7 @@ module.exports = function copyCodeToClipBoard () {
       e.target.blur()
     })
     button.addEventListener('click', e => {
-      // used to detect whether fiddle is installed
-      let windowLostFocus = false
-      const focusLostListener = () => { windowLostFocus = true }
-      window.addEventListener('blur', focusLostListener)
-
-      // try to open fiddle
-      window.location.href = e.target.dataset.fiddleUrl
-
-      // redirect to install page if nothing happened
-      setTimeout(() => {
-        window.removeEventListener('blur', focusLostListener)
-        if (!windowLostFocus) window.location.href = '/fiddle'
-      }, 500)
+      window.open(`https://fiddle.electronjs.org/launch?target=${e.target.dataset.fiddleUrl}`)
     })
   })
 

--- a/scripts/add-code-block-buttons.js
+++ b/scripts/add-code-block-buttons.js
@@ -25,9 +25,9 @@ module.exports = function copyCodeToClipBoard () {
     if (code.dataset.fiddleUrl) {
       const launchButton = document.createElement('button')
       launchButton.classList.add('btn-launch', 'tooltipped', 'tooltipped-n', 'float-left')
-      launchButton.setAttribute('aria-label', 'Launch in Fiddle')
+      launchButton.setAttribute('aria-label', window.localized.fiddle_launch_button.launch_in_fiddle)
       launchButton.setAttribute('data-fiddle-url', code.dataset.fiddleUrl)
-      launchButton.innerHTML = 'Launch'
+      launchButton.innerHTML = window.localized.fiddle_launch_button.launch
       buttonGroup.appendChild(launchButton)
     }
 

--- a/scripts/copy-code-to-clipboard.js
+++ b/scripts/copy-code-to-clipboard.js
@@ -15,12 +15,36 @@ module.exports = function copyCodeToClipBoard () {
   document.querySelectorAll(`code.hljs`).forEach(code => {
     const id = `_${Math.random().toString(36).substr(5)}`
     code.id = id
-    const button = document.createElement('button')
-    button.classList.add('btn-clipboard', 'tooltipped', 'tooltipped-n', 'border', 'float-left')
-    button.setAttribute('aria-label', window.localized.clipboard.copy_to_clipboard)
-    button.setAttribute('data-clipboard-target', `#${id}`)
-    button.innerHTML = window.localized.clipboard.copy
-    code.parentElement.appendChild(button)
+
+    const buttonGroup = document.createElement('div')
+    buttonGroup.classList.add('btn-group', 'border', 'float-left')
+    code.parentElement.appendChild(buttonGroup)
+
+    // add launch button if fiddle is specified
+    if (code.dataset.fiddleUrl) {
+      const launchButton = document.createElement('button')
+      launchButton.classList.add('btn-launch', 'tooltipped', 'tooltipped-n', 'float-left')
+      launchButton.setAttribute('aria-label', 'Launch in Fiddle')
+      launchButton.setAttribute('data-fiddle-url', code.dataset.fiddleUrl)
+      launchButton.innerHTML = 'Launch'
+      buttonGroup.appendChild(launchButton)
+    }
+
+    const copyButton = document.createElement('button')
+    copyButton.classList.add('btn-clipboard', 'tooltipped', 'tooltipped-n', 'float-left')
+    copyButton.setAttribute('aria-label', window.localized.clipboard.copy_to_clipboard)
+    copyButton.setAttribute('data-clipboard-target', `#${id}`)
+    copyButton.innerHTML = window.localized.clipboard.copy
+    buttonGroup.appendChild(copyButton)
+  })
+
+  document.querySelectorAll('.btn-launch').forEach(button => {
+    button.addEventListener('mouseout', e => {
+      e.target.blur()
+    })
+    button.addEventListener('click', e => {
+      window.location.href = e.target.dataset.fiddleUrl
+    })
   })
 
   document.querySelectorAll('.btn-clipboard').forEach(button => {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   require('./apply-active-class-to-active-links')()
   require('./remove-scheme-from-link-text')()
   require('browser-date-formatter')()
-  require('./copy-code-to-clipboard')()
+  require('./add-code-block-buttons')()
   require('./sticky-app-meta')()
   require('./screenshot-thumb-selector')()
   require('./docs-language-toggle')()

--- a/views/partials/head.html
+++ b/views/partials/head.html
@@ -34,6 +34,8 @@
   <meta name="localized.clipboard.copy" content="{{localized.clipboard.copy}}" />
   <meta name="localized.clipboard.copy_to_clipboard" content="{{localized.clipboard.copy_to_clipboard}}" />
   <meta name="localized.clipboard.copied" content="{{localized.clipboard.copied}}" />
+  <meta name="localized.fiddle_launch_button.launch" content="{{localized.fiddle_launch_button.launch}}" />
+  <meta name="localized.fiddle_launch_button.launch_in_fiddle" content="{{localized.fiddle_launch_button.launch_in_fiddle}}" />
 
   <meta name="twitter:site" content="@ElectronJS" />
   <link rel='shortcut icon' href='/images/favicon.ico'/>


### PR DESCRIPTION
Finally the last bit to integrate a `Launch in Fiddle` button to code examples on our webpage.

The button will only be shown if the code block's `data-fiddle-url` html attribute is set (see https://github.com/electron/i18n/pull/769 for more context on how we derive that from the markdown docs).

**To use this feature**, just create a fiddle in the electron repo and add the relative path to the corresponding code block in our `/e/e` docs:
```
```javascript fiddle='{path/to/fiddle/within/e/e}'
const { app } = require('electron')
...
```

cc @felixrieseberg @erickzhao @zeke @HashimotoYT 