### PR TITLE
remove ugly scrollbar if not needed

### DIFF
--- a/public/styles/_app.scss
+++ b/public/styles/_app.scss
@@ -246,7 +246,7 @@
     min-height: 150px;
     max-height: 150px;
     height: 150px;
-    overflow: scroll;
+    overflow: auto;
   }
 }
 


### PR DESCRIPTION
overflow auto only adds scrollbars if they are needed otherwise they wont show up overflow scroll always displays them