### PR TITLE
feat: make announce banner more general

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,8 +158,8 @@ on how to get started, or jump right into translating at
 The top-level banner for showing the information (for example, a new Electron version or important blog post).
 
 To show or update the announcement banner, modify the `announcement` string in
-[`data/locale.yml`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/data/locale.yml#L220) file,
-and update the time inside the `showAnnouncementBanner` constant in [`routes/home.js`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/routes/home.js#L5) file.
+[`data/locale.yml`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/data/locale.yml#L220),
+and update the time inside the `showAnnouncementBanner` constant in [`routes/home.js`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/routes/home.js#L5).
 
 #### Crowdin Proxy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ The top-level banner for showing the information (for example, a new Electron ve
 
 To show or update the announcement banner, modify the `announcement` string in
 [`data/locale.yml`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/data/locale.yml#L220),
-and update the time inside the `showAnnouncementBanner` constant in [`routes/home.js`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/routes/home.js#L5).
+and update the conditional inside the `showAnnouncementBanner` constant in [`routes/home.js`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/routes/home.js#L5).
 
 #### Crowdin Proxy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,9 +155,11 @@ on how to get started, or jump right into translating at
 
 ### Announcement Banner
 
-The top-level banner for showing the information (for example new Electron version, important blog post).
+The top-level banner for showing the information (for example, a new Electron version or important blog post).
 
-For show or update the announcement banner modify the [message](https://github.com/electron/electronjs.org/blob/master/data/locale.yml#L220) and update the show [time](https://github.com/electron/electronjs.org/blob/master/routes/home.js#L5).
+To show or update the announcement banner, modify the `announcement` string in
+[`data/locale.yml`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/data/locale.yml#L220) file,
+and update the time inside the `showAnnouncementBanner` constant in [`routes/home.js`](https://github.com/electron/electronjs.org/blob/efa94cdfbbf6016be7123f4d2ee6a8aa32e2476f/routes/home.js#L5) file.
 
 #### Crowdin Proxy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ feel free to propose changes to this document in a pull request.
   - [Blog](#blog)
   - [Localized Strings](#localized-strings)
   - [Translations](#translations)
+  - [Announcement Banner](#announcement-banner)
 - [Routes](#routes)
 - [Middleware](#middleware)
 - [Views](#views)
@@ -151,6 +152,12 @@ See
 [electron/electron-i18n](https://github.com/electron/electron-i18n) for info
 on how to get started, or jump right into translating at
 [crowdin.com/project/electron](https://crowdin.com/project/electron).
+
+### Announcement Banner
+
+The top-level banner for showing the information (for example new Electron version, important blog post).
+
+For show or update the announcement banner modify the [message](https://github.com/electron/electronjs.org/blob/master/data/locale.yml#L220) and update the show [time](https://github.com/electron/electronjs.org/blob/master/routes/home.js#L5).
 
 #### Crowdin Proxy
 

--- a/data/locale.yml
+++ b/data/locale.yml
@@ -217,8 +217,7 @@ headings:
 
 taglines:
   languages: Localized content from our awesome global developer community.
-  # This is a string is general and can be changed at any time
-  announce: Electron just joined the OpenJS Foundation. See <a href="/blog/electron-joins-openjsf">the announcement</a> for more info!
+  announcement: Electron just joined the OpenJS Foundation. See <a href="/blog/electron-joins-openjsf">the announcement</a> for more info!
 
 help_translate: "Help translate"
 

--- a/data/locale.yml
+++ b/data/locale.yml
@@ -217,7 +217,8 @@ headings:
 
 taglines:
   languages: Localized content from our awesome global developer community.
-  openjsf: Electron just joined the OpenJS Foundation. See <a href="/blog/electron-joins-openjsf">the announcement</a> for more info!
+  # This is a string is general and can be changed at any time
+  announce: Electron just joined the OpenJS Foundation. See <a href="/blog/electron-joins-openjsf">the announcement</a> for more info!
 
 help_translate: "Help translate"
 

--- a/public/styles/_home.scss
+++ b/public/styles/_home.scss
@@ -224,7 +224,7 @@ $app-list-icon-size: 48px;
 
 // Announcement banner------------------------------
 
-.announce-banner {
+.announcement-banner {
   background: #23252f;
   border-bottom: 1px solid #191a22;
   padding-top: 6px;

--- a/routes/home.js
+++ b/routes/home.js
@@ -2,14 +2,14 @@ const shuffle = require('knuth-shuffle-seeded')
 const apps = require('../lib/apps')
 const featuredCompanies = require('../lib/featured-companies')
 
-const showAnnounceBanner = new Date() < new Date(2020, 1, 1)
+const showAnnouncementBanner = new Date() < new Date(2020, 1, 1)
 
 module.exports = (req, res) => {
   const randomizedApps = shuffle(apps.slice())
   const context = Object.assign(req.context, {
     companies: featuredCompanies,
     apps: randomizedApps.slice(0, 25),
-    showAnnounceBanner,
+    showAnnouncementBanner,
   })
 
   res.render('home', context)

--- a/routes/home.js
+++ b/routes/home.js
@@ -2,11 +2,14 @@ const shuffle = require('knuth-shuffle-seeded')
 const apps = require('../lib/apps')
 const featuredCompanies = require('../lib/featured-companies')
 
+const showAnnounceBanner = new Date() < new Date(2020, 1, 1)
+
 module.exports = (req, res) => {
   const randomizedApps = shuffle(apps.slice())
   const context = Object.assign(req.context, {
     companies: featuredCompanies,
-    apps: randomizedApps.slice(0, 25)
+    apps: randomizedApps.slice(0, 25),
+    showAnnounceBanner,
   })
 
   res.render('home', context)

--- a/views/home.html
+++ b/views/home.html
@@ -1,5 +1,5 @@
 <main class="homepage PRIMER-REMOVE-ME">
-  {{> announce_banner}}
+  {{> announcement_banner}}
   <div class="py-6 py-sm-8 jumbotron jumbotron-home ">
     <div class="container-xl p-responsive position-relative text-center">
       {{> hero}}

--- a/views/home.html
+++ b/views/home.html
@@ -1,7 +1,5 @@
 <main class="homepage PRIMER-REMOVE-ME">
-  <div class="announce-banner">
-    {{{localized.taglines.openjsf}}}
-  </div>
+  {{> announce_banner}}
   <div class="py-6 py-sm-8 jumbotron jumbotron-home ">
     <div class="container-xl p-responsive position-relative text-center">
       {{> hero}}

--- a/views/partials/announce_banner.html
+++ b/views/partials/announce_banner.html
@@ -1,0 +1,5 @@
+{{#if showAnnounceBanner}}
+<div class="announce-banner">
+  {{{localized.taglines.announce}}}
+</div>
+{{/if}}

--- a/views/partials/announce_banner.html
+++ b/views/partials/announce_banner.html
@@ -1,5 +1,0 @@
-{{#if showAnnounceBanner}}
-<div class="announce-banner">
-  {{{localized.taglines.announce}}}
-</div>
-{{/if}}

--- a/views/partials/announcement_banner.html
+++ b/views/partials/announcement_banner.html
@@ -1,0 +1,5 @@
+{{#if showAnnouncementBanner}}
+<div class="announcement-banner">
+  {{{localized.taglines.announcement}}}
+</div>
+{{/if}}


### PR DESCRIPTION
This Pull Request makes announce banner more general and allows us to use them by folks for another announcement.

For using its need to change the message in `locale.yml` and update show date in `home.js`, and it's all 🙃

> Side note, should be this be documented in contrib docs?