### PR TITLE
build(deps): Revert "build(deps): bump @primer/css from 12.5.0 to 14.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,12 +1963,9 @@
       }
     },
     "@primer/css": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@primer/css/-/css-14.2.0.tgz",
-      "integrity": "sha512-BvBuw0V8ypOFpFhvXRpPWQQ3w/piUMS/Pp/rRg3ddnw0eu2keC2Sj+CzJv3ofsiGoq7juHGfGQlqkOWmSQjXRw==",
-      "requires": {
-        "@primer/octicons": "^9.1.1"
-      }
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@primer/css/-/css-12.5.0.tgz",
+      "integrity": "sha512-MyA2hoCY3UAmMKPHPN+LM1HrwGz5VR92fkEkIzAQgHBYMPstT77tjHkO8OPoWW//DShdYMYAgukZdMJ8lnsfbg=="
     },
     "@primer/octicons": {
       "version": "9.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.6.0",
-    "@primer/css": "^14.2.0",
+    "@primer/css": "^12.5.0",
     "awesome-electron": "2.6.0",
     "babelify": "^10.0.0",
     "brfs": "^2.0.2",


### PR DESCRIPTION
Reverts electron/electronjs.org#3461

It contains visible breaking changes. Should be covered by #3297.

/cc @ckerr 