### PR TITLE
fix: text breaking on home page

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -83,31 +83,31 @@
       <div class="col-xs-12 col-sm-4 col-md-2 offset-md-1 mb-xs-4 mb-md-0 hero-feature">
         <a class="hero-link" href="/docs/api/auto-updater/">
           <span class="octicon hero-octicon octicon-squirrel" aria-hidden="true"></span>
-          {{{localized.benefits.automatic_updates}}}
+          <div>{{{localized.benefits.automatic_updates}}}</div>
         </a>
       </div>
       <div class='col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature'>
         <a class="hero-link" href="/docs/api/menu">
           <span class="octicon hero-octicon octicon-device-desktop" aria-hidden="true"></span>
-          {{{localized.benefits.native_menus_and_notifications}}}
+          <div>{{{localized.benefits.native_menus_and_notifications}}}</div>
         </a>
       </div>
       <div class='col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature'>
         <a class="hero-link" href="/docs/api/crash-reporter">
           <span class="octicon hero-octicon octicon-bug" style="padding-left:2px" aria-hidden="true"></span>
-          {{{localized.benefits.crash_reporting}}}
+          <div>{{{localized.benefits.crash_reporting}}}</div>
         </a>
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature">
         <a class="hero-link" href="/docs/api/content-tracing">
           <span class="octicon hero-octicon octicon-tools" aria-hidden="true"></span>
-          {{{localized.benefits.debugging_and_profiling}}}
+          <div>{{{localized.benefits.debugging_and_profiling}}}</div>
         </a>
       </div>
       <div class='col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature'>
         <a class="hero-link" href="/docs/api/auto-updater/#windows">
           <span class="octicon hero-octicon octicon-gift" style="padding-right:2px" aria-hidden="true"></span>
-          {{{localized.benefits.windows_installers}}}
+          <div>{{{localized.benefits.windows_installers}}}</div>
         </a>
       </div>
     </div>


### PR DESCRIPTION
Fixes text breaking on home page #3527.

**Initial state**
![image](https://user-images.githubusercontent.com/2415410/75598590-182a1d80-5a9d-11ea-832b-557800c04782.png)

**Resulting state**
![image](https://user-images.githubusercontent.com/2415410/75598594-2d06b100-5a9d-11ea-876a-2bad3219996b.png)

