### PR TITLE
fix: restore hero-octicon CSS specificity

### DIFF
--- a/public/styles/helpers/_icons.scss
+++ b/public/styles/helpers/_icons.scss
@@ -1,7 +1,6 @@
 // Icon styles
 // --------------------------------------------------
 
-
 [class*="hero-octicon"] {
   display: block;
   width: 75px;

--- a/public/styles/helpers/_icons.scss
+++ b/public/styles/helpers/_icons.scss
@@ -1,6 +1,7 @@
 // Icon styles
 // --------------------------------------------------
 
+
 [class*="hero-octicon"] {
   display: block;
   width: 75px;
@@ -13,6 +14,10 @@
   background-color: #fff;
   border: 1px solid $gray-5;
   border-radius: 50%;
+
+  .PRIMER-REMOVE-ME & {
+    @extend [class*="hero-octicon"];
+  }
 }
 
 [class*="inline-octicon"]  {


### PR DESCRIPTION
Fixes #3527.

The addition of `.PRIMER-REMOVE-ME` added increased CSS specificity to all `@primer/css` styles. This led to these default styles overriding our custom styles, such as `[class*="hero-octicon"]`.

This PR restores specificity for this particular style by duplicating the `[class*="hero-octicon"]` selector into a new `.PRIMER-REMOVE-ME [class*="hero-octicon"]` selector.

### Screenshot

cc @codebytere @HashimotoYT