### PR TITLE
chore: Add note about Spectron being unmaintained

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -454,7 +454,7 @@ describe('electronjs.org', () => {
       let $ = await get('/devtron')
       $('.jumbotron-lead .jumbotron-lead-muted').text().should.eq('An Electron DevTools Extension')
       $ = await get('/spectron')
-      $('.jumbotron-lead .jumbotron-lead-muted').text().should.eq('An Electron Testing Framework')
+      $('.jumbotron-lead .jumbotron-lead-muted').text().should.eq('An Electron Testing Framework (currently unmaintained)')
     })
   })
 

--- a/views/spectron.html
+++ b/views/spectron.html
@@ -3,7 +3,7 @@
     <div class="container">
       <img class="mb-4 mb-lg-6" src="{{ site.baseurl }}/images/spectron-icon.svg" alt="Spectron icon">
       <p><img src="{{ site.baseurl }}/images/spectron-logo.svg" alt="Spectron logo"></p>
-      <p class='jumbotron-lead'><span class='jumbotron-lead-muted'>An Electron Testing Framework</span></p>
+      <p class='jumbotron-lead'><span class='jumbotron-lead-muted'>An Electron Testing Framework (currently unmaintained)</span></p>
     </div>
   </div>
 

--- a/views/userland/spectron.html
+++ b/views/userland/spectron.html
@@ -3,7 +3,7 @@
     <div class="container">
       <img class="mb-4 mb-lg-6" src="{{ site.baseurl }}/images/spectron-icon.svg" alt="Spectron icon">
       <p><img src="{{ site.baseurl }}/images/spectron-logo.svg" alt="Spectron logo"></p>
-      <p class='jumbotron-lead'><span class='jumbotron-lead-muted'>An Electron Testing Framework</span></p>
+      <p class='jumbotron-lead'><span class='jumbotron-lead-muted'>An Electron Testing Framework (currently unmaintained)</span></p>
     </div>
   </div>
 


### PR DESCRIPTION
Spectron hasn't had any updates for something like a couple years now, save for version bumps and automated minor dependency updates. [This pull request](https://github.com/electron-userland/spectron/pull/345) to update an out-of-date link in the README has been open for more than a year now.

With the current state of the project, I don't think it makes sense to call Spectron "officially supported" without some kind of note that it's not being maintained. At the very least, there should be some kind of warning so that folks aren't encouraged to start new projects using Spectron.

