### PR TITLE
fix: disallow using node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "walk-sync": "^2.1.0"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">=12 <14"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Too fast to pick Node 14