### PR TITLE
chore: switch from standard to eslint + prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  },
+  extends: [
+    'prettier',
+    'plugin:prettier/recommended',
+  ],
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": false,
+  "proseWrap": "always"
+}

--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -65,9 +65,10 @@ describe('electronjs.org', () => {
       cy.get('a[href="/docs"]:first').click()
       cy.wait(500)
 
-      cy.get('.container-lg')
-      .contains('Electron Documentation')
-      cy.get('.container-lg p').contains('See all of the docs on one page or check out the FAQ.')
+      cy.get('.container-lg').contains('Electron Documentation')
+      cy.get('.container-lg p').contains(
+        'See all of the docs on one page or check out the FAQ.'
+      )
     })
 
     it('documentation page has guides, api references, and advanced sections', () => {
@@ -85,9 +86,10 @@ describe('electronjs.org', () => {
       cy.get('a[href="/blog"]:first').click()
       cy.wait(500)
 
-      cy.get('.container-lg')
-        .contains('Electron Blog')
-      cy.get('.container-lg p').contains('All the latest news from the Electron team and community.')
+      cy.get('.container-lg').contains('Electron Blog')
+      cy.get('.container-lg p').contains(
+        'All the latest news from the Electron team and community.'
+      )
     })
 
     it('open blog post', () => {
@@ -110,14 +112,17 @@ describe('electronjs.org', () => {
       cy.get('.nav-search').type('window')
       cy.wait(500)
       let types = ['#tutorial-hits', '#api-hits', '#package-hits', '#app-hits']
-      types.forEach(type =>{
-        cy.get(type)
-          .should(typeHits => {
-            if(type.includes('tutorial')) expect(typeHits.first()).to.contain('Windows Taskbar')
-            if (type.includes('api')) expect(typeHits.first()).to.contain('window-all-closed')
-            if (type.includes('package')) expect(typeHits.first()).to.contain('about-window')
-            if (type.includes('app')) expect(typeHits.first()).to.contain('PhotoScreenSaver')
-          })
+      types.forEach((type) => {
+        cy.get(type).should((typeHits) => {
+          if (type.includes('tutorial'))
+            expect(typeHits.first()).to.contain('Windows Taskbar')
+          if (type.includes('api'))
+            expect(typeHits.first()).to.contain('window-all-closed')
+          if (type.includes('package'))
+            expect(typeHits.first()).to.contain('about-window')
+          if (type.includes('app'))
+            expect(typeHits.first()).to.contain('PhotoScreenSaver')
+        })
       })
     })
 
@@ -148,8 +153,8 @@ describe('electronjs.org', () => {
     // })
   })
 
-    // The test is intentionally disabled while the new temporary homepage
-    // is in place
+  // The test is intentionally disabled while the new temporary homepage
+  // is in place
   describe('localization', () => {
     it('change language via language drop-down menu', () => {
       cy.visit(`${localhost}`)
@@ -189,7 +194,9 @@ describe('electronjs.org', () => {
   describe('landing pages', () => {
     it('Fiddle landing page', () => {
       cy.visit(`${localhost}/fiddle`)
-      cy.get('.jumbotron-lead').contains('The easiest way to get started with Electron')
+      cy.get('.jumbotron-lead').contains(
+        'The easiest way to get started with Electron'
+      )
     })
 
     it('Devtron landing page', () => {
@@ -212,13 +219,15 @@ describe('electronjs.org', () => {
     })
 
     it('responsive navbar', () => {
-      cy.viewport('iphone-6', "portrait")
+      cy.viewport('iphone-6', 'portrait')
       cy.visit(`${localhost}/releases/stable`)
       cy.get('#release-navbar').should('have.class', 'd-none')
       cy.get('.r-resp-header-toggle').should('be.visible').click()
 
       cy.get('#release-navbar').should('not.have.class', 'd-none')
-      cy.get('#release-navbar > h3').should('be.visible').contains('Show Releases:')
+      cy.get('#release-navbar > h3')
+        .should('be.visible')
+        .contains('Show Releases:')
     })
 
     // FIXME: expected '' to equal 301
@@ -236,14 +245,18 @@ describe('electronjs.org', () => {
   describe('Buggy Tests', () => {
     it('language bar responsive bug', () => {
       visit()
-      cy.get('.lang-select-button').click()
-        .get('#languages-header-menu').should('have.css', 'height', '415px')
+      cy.get('.lang-select-button')
+        .click()
+        .get('#languages-header-menu')
+        .should('have.css', 'height', '415px')
         .viewport('iphone-6')
         .wait(500)
-        .get('#languages-header-menu').should('have.css', 'height', '868px')
+        .get('#languages-header-menu')
+        .should('have.css', 'height', '868px')
         .viewport(1920, 1080)
         // .get('#languages-header-menu').should('have.css', 'height', '415px') // FIXME: Uncomment when fixed.
-        .get('#languages-header-menu').should('have.css', 'height', '868px')
+        .get('#languages-header-menu')
+        .should('have.css', 'height', '868px')
     })
   })
 })

--- a/lib/apps.js
+++ b/lib/apps.js
@@ -1,4 +1,5 @@
-const apps = require('electron-apps')
-  .sort((a, b) => new Date(b.date) - new Date(a.date))
+const apps = require('electron-apps').sort(
+  (a, b) => new Date(b.date) - new Date(a.date)
+)
 
 module.exports = apps

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -4,39 +4,39 @@ const graymatter = require('gray-matter')
 const fs = require('fs-extra')
 const path = require('path')
 
-function parseMarkdown (markdown) {
+function parseMarkdown(markdown) {
   // Using unsafe options as we trust the blog content from this repo
   return markdownToHtml(markdown, {
     unsafe: true,
     extensions: {
-      tagfilter: false
-    }
+      tagfilter: false,
+    },
   })
 }
 
 const POSTS_PATH = path.join(__dirname, '..', 'data', 'blog')
 class BlogPost {
-  static async getAll (language) {
+  static async getAll(language) {
     const files = await fs.readdir(POSTS_PATH)
-    const slugs = files.map(file => path.basename(file, '.md'))
+    const slugs = files.map((file) => path.basename(file, '.md'))
     return slugs.map((slug) => BlogPost.get(slug, language))
   }
 
-  static get (slug, language) {
+  static get(slug, language) {
     return new BlogPost(slug, language)
   }
 
-  constructor (slug, language) {
+  constructor(slug, language) {
     this._cache = new Map()
     this._slug = slug
     this._language = language
   }
 
-  exists () {
+  exists() {
     return fs.exists(path.join(POSTS_PATH, this.filename()))
   }
 
-  async cache (key, computation) {
+  async cache(key, computation) {
     if (this._cache.has(key)) {
       return this._cache.get(key)
     } else {
@@ -46,7 +46,7 @@ class BlogPost {
     }
   }
 
-  _getRawMarkdown () {
+  _getRawMarkdown() {
     // This block looks not very good, but they give confidence,
     // and security that we do not get the crash when the content
     // not synchronized in the i18n, e.g. when we publish a new post,
@@ -69,52 +69,52 @@ class BlogPost {
     return this.cache('_getRawMarkdown', () => fs.readFile(fullPath))
   }
 
-  async _frontmatter () {
+  async _frontmatter() {
     const markdown = await this._getRawMarkdown()
     return this.cache('frontmatter', () => {
       return graymatter(markdown, {
         excerpt: true,
-        excerpt_separator: '---'
+        excerpt_separator: '---',
       })
     })
   }
 
-  async frontmatter (key) {
+  async frontmatter(key) {
     const fm = await this._frontmatter()
     return fm.data[key]
   }
 
-  slug () {
+  slug() {
     return this._slug
   }
 
-  filename () {
+  filename() {
     return `${this.slug()}.md`
   }
 
-  title () {
+  title() {
     return this.frontmatter('title')
   }
 
-  date () {
+  date() {
     return this.frontmatter('date')
   }
 
-  href () {
+  href() {
     return `/blog/${this.slug()}`
   }
 
-  async authors () {
+  async authors() {
     const authors = await this.frontmatter('author')
     return Array.isArray(authors) ? authors : [authors]
   }
 
-  async excerpt () {
+  async excerpt() {
     const { excerpt } = await this._frontmatter()
     return this.cache('excerpt', () => parseMarkdown(excerpt))
   }
 
-  async content () {
+  async content() {
     const { content } = await this._frontmatter()
     return this.cache('content', () => parseMarkdown(content))
   }

--- a/lib/featured-apps.js
+++ b/lib/featured-apps.js
@@ -3,8 +3,8 @@ const developer = [
     name: 'Visual Studio Code',
     screenshot: 'vscode',
     url: 'https://code.visualstudio.com/',
-    icon: 'vscode-icon.svg'
-  }
+    icon: 'vscode-icon.svg',
+  },
 ]
 
 const messenger = [
@@ -12,13 +12,14 @@ const messenger = [
     name: 'Facebook Messenger',
     screenshot: 'messenger',
     url: 'https://www.messenger.com/desktop',
-    icon: 'messenger-icon.svg'
-  }, {
+    icon: 'messenger-icon.svg',
+  },
+  {
     name: 'WhatsApp',
     screenshot: 'whatsapp',
     url: 'https://www.whatsapp.com',
-    icon: 'whatsapp-icon.svg'
-  }
+    icon: 'whatsapp-icon.svg',
+  },
 ]
 
 const collaboration = [
@@ -26,13 +27,15 @@ const collaboration = [
     name: 'Slack',
     screenshot: 'slack',
     url: 'https://slack.com',
-    icon: 'slack-icon.svg'
-  }, {
+    icon: 'slack-icon.svg',
+  },
+  {
     name: 'Microsoft Teams',
     screenshot: 'teams',
-    url: 'https://products.office.com/en-US/microsoft-teams/group-chat-software',
-    icon: 'teams-icon.svg'
-  }
+    url:
+      'https://products.office.com/en-US/microsoft-teams/group-chat-software',
+    icon: 'teams-icon.svg',
+  },
 ]
 
 const entertainment = [
@@ -40,8 +43,8 @@ const entertainment = [
     name: 'Twitch',
     screenshot: 'twitch',
     url: 'https://twitch.com',
-    icon: 'twitch-icon.svg'
-  }
+    icon: 'twitch-icon.svg',
+  },
 ]
 
 const design = [
@@ -49,13 +52,14 @@ const design = [
     name: 'Figma',
     screenshot: 'figma',
     url: 'https://figma.com',
-    icon: 'figma-icon.png'
-  }, {
+    icon: 'figma-icon.png',
+  },
+  {
     name: 'InVision',
     screenshot: 'invision',
     url: 'https://invisionapp.com',
-    icon: 'invision-icon.svg'
-  }
+    icon: 'invision-icon.svg',
+  },
 ]
 
 const featuredApps = {
@@ -63,7 +67,7 @@ const featuredApps = {
   messenger,
   entertainment,
   collaboration,
-  design
+  design,
 }
 
 module.exports = featuredApps

--- a/lib/featured-companies.js
+++ b/lib/featured-companies.js
@@ -6,46 +6,46 @@ module.exports = [
   {
     name: 'Discord',
     img: 'discord.png',
-    url: 'https://discordapp.com/'
+    url: 'https://discordapp.com/',
   },
   {
     name: 'OpenFin',
     img: 'openfin.png',
-    url: 'https://openfin.co/'
+    url: 'https://openfin.co/',
   },
   {
     name: 'Slack',
     img: 'slack.png',
-    url: 'https://slack.com/'
+    url: 'https://slack.com/',
   },
   {
     name: 'Microsoft',
     img: 'msft.png',
-    url: 'https://www.microsoft.com/'
+    url: 'https://www.microsoft.com/',
   },
   {
     name: 'Symphony',
     img: 'symphony.png',
-    url: 'https://symphony.com/'
+    url: 'https://symphony.com/',
   },
   {
     name: 'Atlassian',
     img: 'atlassian.png',
-    url: 'https://www.atlassian.com/'
+    url: 'https://www.atlassian.com/',
   },
   {
     name: 'Abstract',
     img: 'abstract.png',
-    url: 'https://www.abstract.com/'
+    url: 'https://www.abstract.com/',
   },
   {
     name: 'RingCentral',
     img: 'ringcentral.png',
-    url: 'https://www.ringcentral.com/'
+    url: 'https://www.ringcentral.com/',
   },
   {
     name: 'Aircall',
     img: 'aircall.png',
-    url: 'https://aircall.io/'
-  }
+    url: 'https://aircall.io/',
+  },
 ]

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -11,8 +11,8 @@ const emailPattern = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
 
 // If any website strings are missing from electron-i18n,
 // fill them in with the corresponding value from ../data/locale.yml
-locales.forEach(locale => {
-  websiteKeys.forEach(key => {
+locales.forEach((locale) => {
+  websiteKeys.forEach((key) => {
     const deepKey = `website.${locale}.${key}`
     // Always use local locale.yml data for English,
     // and backfill to English for missing entries in other languages.
@@ -22,21 +22,23 @@ locales.forEach(locale => {
   })
 })
 
-function containsEmail (string) {
+function containsEmail(string) {
   return typeof string === 'string' && string.match(emailPattern)
 }
 
-function obfuscate (string) {
-  return string.replace(emailPattern, match => {
-    return Array.prototype.map.call(match, chr => {
-      return `&#${chr.charCodeAt(0)};`
-    }).join('')
+function obfuscate(string) {
+  return string.replace(emailPattern, (match) => {
+    return Array.prototype.map
+      .call(match, (chr) => {
+        return `&#${chr.charCodeAt(0)};`
+      })
+      .join('')
   })
 }
 
 const keys = Object.keys(flat(i18n))
 
-keys.forEach(key => {
+keys.forEach((key) => {
   const value = get(i18n, key)
   if (containsEmail(value)) {
     set(i18n, key, obfuscate(value))

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -1,24 +1,24 @@
 const semver = require('semver')
 
 class Release {
-  constructor (releaseData) {
+  constructor(releaseData) {
     this.data = releaseData
     this.semver = semver.parse(this.data.version)
   }
 
-  isStable () {
+  isStable() {
     return !this.isBeta() && !this.isNightly()
   }
 
-  isBeta () {
+  isBeta() {
     return this.semver.prerelease.includes('beta')
   }
 
-  isNightly () {
+  isNightly() {
     return this.semver.prerelease.includes('nightly')
   }
 
-  hasNpmDistTag (tag) {
+  hasNpmDistTag(tag) {
     if (this.data.npm_dist_tags) {
       return this.data.npm_dist_tags.includes(tag)
     } else {
@@ -28,24 +28,24 @@ class Release {
 }
 
 class Releases {
-  constructor (releases) {
-    this.all = releases.map(r => new Release(r))
+  constructor(releases) {
+    this.all = releases.map((r) => new Release(r))
 
     // electron-releases data is already sorted in version order,
     // highest version to lowest.
-    this.stableRelease = this.all.find(r => r.hasNpmDistTag('latest'))
-    this.betaRelease = this.all.find(r => r.hasNpmDistTag('beta'))
-    this.nightlyRelease = this.all.find(r => r.hasNpmDistTag('nightly'))
+    this.stableRelease = this.all.find((r) => r.hasNpmDistTag('latest'))
+    this.betaRelease = this.all.find((r) => r.hasNpmDistTag('beta'))
+    this.nightlyRelease = this.all.find((r) => r.hasNpmDistTag('nightly'))
   }
 
-  ofType (type) {
+  ofType(type) {
     switch (type) {
       case 'stable':
-        return this.all.filter(r => r.isStable())
+        return this.all.filter((r) => r.isStable())
       case 'beta':
-        return this.all.filter(r => r.isBeta())
+        return this.all.filter((r) => r.isBeta())
       case 'nightly':
-        return this.all.filter(r => r.isNightly())
+        return this.all.filter((r) => r.isNightly())
       default:
         throw new Error(`Invalid release type: ${type}`)
     }

--- a/middleware/browserify-opts.js
+++ b/middleware/browserify-opts.js
@@ -1,24 +1,23 @@
-const nodeModulesToAvoidBabelifying = [
-  'lodash',
-  'lunr',
-  'prettydate'
-]
+const nodeModulesToAvoidBabelifying = ['lodash', 'lunr', 'prettydate']
 
-const excludeRegex = new RegExp(`/node_modules/(${nodeModulesToAvoidBabelifying.join('|')})`)
+const excludeRegex = new RegExp(
+  `/node_modules/(${nodeModulesToAvoidBabelifying.join('|')})`
+)
 
-module.exports = function doBrowserify (browserify) {
+module.exports = function doBrowserify(browserify) {
   return function (entry) {
     return browserify(entry, {
       transform: [
-        ['babelify', {
-          global: true,
-          exclude: excludeRegex,
-          presets: [
-            ['@babel/preset-env', { targets: '> 0.25%, not dead' }]
-          ]
-        }],
-        'brfs'
-      ]
+        [
+          'babelify',
+          {
+            global: true,
+            exclude: excludeRegex,
+            presets: [['@babel/preset-env', { targets: '> 0.25%, not dead' }]],
+          },
+        ],
+        'brfs',
+      ],
     })
   }
 }

--- a/middleware/browsersync.js
+++ b/middleware/browsersync.js
@@ -1,7 +1,7 @@
 const env = require('lil-env-thing')
 const path = require('path')
 
-module.exports = function browsersync () {
+module.exports = function browsersync() {
   if (env.test || env.production) return noop
 
   const bs = require('browser-sync')({
@@ -11,14 +11,14 @@ module.exports = function browsersync () {
       path.join(__dirname, '../**/*.html'),
       // path.join(__dirname, '../**/*.scss'),
       path.join(__dirname, '../data/**/*'),
-      path.join(__dirname, '../js/**/*')
+      path.join(__dirname, '../js/**/*'),
     ],
     logSnippet: false,
-    logLevel: 'silent'
+    logLevel: 'silent',
   })
   return require('connect-browser-sync')(bs)
 }
 
-function noop (req, res, next) {
+function noop(req, res, next) {
   return next()
 }

--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -1,12 +1,14 @@
 const i18n = require('lib/i18n')
 const electronReleases = require('electron-releases')
-const { deps } = electronReleases.find(release => release.version === i18n.electronLatestStableVersion)
+const { deps } = electronReleases.find(
+  (release) => release.version === i18n.electronLatestStableVersion
+)
 const { getLanguageNativeName } = require('locale-code')
 const rtlDetect = require('rtl-detect')
 const Releases = require('../lib/releases')
 
 // Supply all route handlers with a baseline `req.context` object
-module.exports = function contextBuilder (req, res, next) {
+module.exports = function contextBuilder(req, res, next) {
   // Attach i18n object to request so any route handler can use it if needed
   req.i18n = i18n
 
@@ -26,10 +28,13 @@ module.exports = function contextBuilder (req, res, next) {
   const localized = i18n.website[req.language]
 
   // Page titles, descriptions, etc
-  let page = Object.assign({
-    title: 'Electron',
-    path: req.path
-  }, i18n.website[req.language].pages[req.path])
+  let page = Object.assign(
+    {
+      title: 'Electron',
+      path: req.path,
+    },
+    i18n.website[req.language].pages[req.path]
+  )
 
   if (req.path !== '/') {
     page.title = `${page.title} | Electron`
@@ -39,7 +44,10 @@ module.exports = function contextBuilder (req, res, next) {
     electronLatestStableVersion: i18n.electronLatestStableVersion,
     electronLatestStableTag: i18n.electronLatestStableTag,
     electronMasterBranchCommit: i18n.electronMasterBranchCommit,
-    electronMasterBranchCommitShort: i18n.electronMasterBranchCommit.slice(0, 6),
+    electronMasterBranchCommitShort: i18n.electronMasterBranchCommit.slice(
+      0,
+      6
+    ),
     deps: deps,
     releases: new Releases(electronReleases),
     currentLocale: req.language,
@@ -49,7 +57,7 @@ module.exports = function contextBuilder (req, res, next) {
     page: page,
     showAnnouncementBanner: true,
     localized: localized,
-    cookies: req.cookies
+    cookies: req.cookies,
   }
 
   if (req.path.startsWith('/docs')) {

--- a/middleware/lang-resolver.js
+++ b/middleware/lang-resolver.js
@@ -7,7 +7,7 @@ var lowerLangRegion = {}
 var lowerLang = {}
 // Keep all the language/region and language in a object
 // with property names in lowercases to resolve the lang code
-locales.forEach(locale => {
+locales.forEach((locale) => {
   // map locale in lowercase
   lowerLangRegion[locale.toLowerCase()] = locale
 
@@ -19,7 +19,7 @@ locales.forEach(locale => {
   }
 })
 
-function resolve (lang) {
+function resolve(lang) {
   var lower = lang.toLowerCase()
   if (lowerLangRegion.hasOwnProperty(lower)) {
     return lowerLangRegion[lower]
@@ -33,11 +33,11 @@ function resolve (lang) {
   return lang
 }
 
-function parseurl (req) {
+function parseurl(req) {
   return url.parse(req.url)
 }
 
-module.exports = function langResolver (req, res, next) {
+module.exports = function langResolver(req, res, next) {
   if (req.query.lang) {
     // resolving lang to lang-REGION when
     //    - cases does not match
@@ -49,7 +49,8 @@ module.exports = function langResolver (req, res, next) {
       const parsedUrl = parseurl(req)
       req.query.lang = rlang
       return res.redirect(
-        url.format({ pathname: parsedUrl.pathname, query: req.query }))
+        url.format({ pathname: parsedUrl.pathname, query: req.query })
+      )
     }
   }
 

--- a/middleware/register-octicons.js
+++ b/middleware/register-octicons.js
@@ -13,7 +13,13 @@ const octicons = require('@primer/octicons')
  * @param {String} ariaLabel Add accessibility `aria-label` to the icon.
  * @returns {Promise<any>} Returns a string of the `<svg>` tag.
  */
-module.exports = async function getOcticons (name, className, width, height, ariaLabel) {
+module.exports = async function getOcticons(
+  name,
+  className,
+  width,
+  height,
+  ariaLabel
+) {
   // Strict Null Checking
   if (name === undefined || name === null) {
     return
@@ -23,7 +29,7 @@ module.exports = async function getOcticons (name, className, width, height, ari
     class: className || null,
     width: width || null,
     height: height || null,
-    'aria-label': ariaLabel || null
+    'aria-label': ariaLabel || null,
   }
 
   if (opts.class === null) delete opts.class

--- a/middleware/sass.js
+++ b/middleware/sass.js
@@ -8,6 +8,6 @@ module.exports = function () {
     debug: false,
     includePaths: path.join(__dirname, '../node_modules'),
     // outputStyle: 'compressed',
-    prefix: '/styles'
+    prefix: '/styles',
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1421,9 +1421,9 @@
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
     },
     "acorn-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "acorn-node": {
@@ -1463,12 +1463,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-      "dev": true
     },
     "algoliasearch": {
       "version": "3.30.0",
@@ -1700,16 +1694,6 @@
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
-    "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
-      }
-    },
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -1793,6 +1777,12 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -1865,50 +1855,6 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
           "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
-          "dev": true
-        }
-      }
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -3840,9 +3786,9 @@
       "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "check-error": {
@@ -3948,12 +3894,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4055,9 +3995,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "clipboard": {
@@ -4432,12 +4372,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
-    },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -4885,12 +4819,6 @@
         "ms": "^2.1.1"
       }
     },
-    "debug-log": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-      "dev": true
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -4996,28 +4924,6 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
-    "deglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
-      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
-      "dev": true,
-      "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^3.0.9",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-          "dev": true
-        }
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5110,9 +5016,9 @@
       "integrity": "sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q=="
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -5491,30 +5397,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "es5-ext": {
       "version": "0.10.48",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.48.tgz",
@@ -5611,373 +5493,190 @@
       }
     },
     "eslint": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
-      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.0",
-        "babel-code-frame": "^6.26.0",
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.2",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^5.2.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.11.0",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
-        "text-table": "^0.2.0"
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
-        "pluralize": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
+        },
+        "strip-json-comments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+          "dev": true
         }
       }
     },
-    "eslint-config-standard": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
-      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
-      "dev": true
-    },
-    "eslint-config-standard-jsx": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
-      "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
-      "dev": true
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+    "eslint-config-prettier": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "get-stdin": "^6.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
           "dev": true
         }
       }
     },
-    "eslint-module-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+    "eslint-plugin-prettier": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0"
-          }
-        }
+        "prettier-linter-helpers": "^1.0.0"
       }
-    },
-    "eslint-plugin-es": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
-      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
-      "dev": true,
-      "requires": {
-        "eslint-utils": "^1.3.0",
-        "regexpp": "^2.0.1"
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
-      "dev": true,
-      "requires": {
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
-      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-es": "^1.3.1",
-        "eslint-utils": "^1.3.1",
-        "ignore": "^4.0.2",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-promise": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
-      "dev": true
-    },
-    "eslint-plugin-react": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "eslint-plugin-standard": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
-      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
-      "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -5985,29 +5684,37 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -6016,12 +5723,20 @@
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -6371,13 +6086,13 @@
       }
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       },
       "dependencies": {
@@ -6471,6 +6186,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -6527,13 +6248,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-uri-to-path": {
@@ -6597,12 +6317,6 @@
         }
       }
     },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
-    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -6637,16 +6351,32 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -8070,9 +7800,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -8183,99 +7913,180 @@
       }
     },
     "inquirer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "dev": true,
           "requires": {
-            "restore-cursor": "^2.0.0"
+            "type-fest": "^0.11.0"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
           "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "dev": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "^2.1.0"
           }
         },
         "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
           "dev": true,
           "requires": {
-            "onetime": "^2.0.0",
+            "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
           }
         },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+        "rxjs": {
+          "version": "6.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+          "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "tslib": "^1.9.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
         }
       }
     },
@@ -8388,12 +8199,6 @@
       "requires": {
         "builtin-modules": "^1.0.0"
       }
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -8580,21 +8385,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
@@ -8827,15 +8617,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3"
       }
     },
     "keycode": {
@@ -9895,9 +9676,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "nan": {
@@ -10932,12 +10713,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
       "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
     },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
-    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -10949,106 +10724,6 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
-      }
-    },
-    "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
-    "pkg-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true,
-      "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -11263,6 +10938,21 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "pretty-bytes": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
@@ -11295,9 +10985,9 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise": {
@@ -12152,39 +11842,6 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      },
-      "dependencies": {
-        "caller-path": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-          "dev": true,
-          "requires": {
-            "callsites": "^0.2.0"
-          }
-        },
-        "callsites": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-          "dev": true
-        }
-      }
-    },
     "require-yaml": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/require-yaml/-/require-yaml-0.0.1.tgz",
@@ -12318,18 +11975,9 @@
       "integrity": "sha512-5X1422hvphzg2a/bo4tIDbjFjbJUOaPZwqE6dnyyxqwFqfR+tBcvfqapJr0o0VygATVCGKiODEewhZtKF+90AA=="
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
-    },
-    "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
     },
     "rx": {
@@ -13268,43 +12916,6 @@
       "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
       "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE="
     },
-    "standard": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-12.0.1.tgz",
-      "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
-      "dev": true,
-      "requires": {
-        "eslint": "~5.4.0",
-        "eslint-config-standard": "12.0.0",
-        "eslint-config-standard-jsx": "6.0.2",
-        "eslint-plugin-import": "~2.14.0",
-        "eslint-plugin-node": "~7.0.1",
-        "eslint-plugin-promise": "~4.0.0",
-        "eslint-plugin-react": "~7.11.1",
-        "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "~9.0.0"
-      }
-    },
-    "standard-engine": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-9.0.0.tgz",
-      "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
-      "dev": true,
-      "requires": {
-        "deglob": "^2.1.0",
-        "get-stdin": "^6.0.0",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-          "dev": true
-        }
-      }
-    },
     "static-eval": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
@@ -13893,23 +13504,45 @@
       }
     },
     "table": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -13919,31 +13552,34 @@
           "dev": true
         },
         "slice-ansi": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
           "dev": true,
           "requires": {
+            "ansi-styles": "^3.2.0",
+            "astral-regex": "^1.0.0",
             "is-fullwidth-code-point": "^2.0.0"
           }
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -14444,12 +14080,6 @@
         }
       }
     },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
-    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -14733,6 +14363,12 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -14951,6 +14587,12 @@
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -14972,9 +14614,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max_old_space_size=4096' NODE_PATH=. NODE_ENV=production node server.js",
     "bootstrap": "node script/bootstrap",
-    "test": "cross-env NODE_PATH=. NODE_ENV=test mocha --timeout 5000 && standard --fix",
+    "test": "cross-env NODE_PATH=. NODE_ENV=test mocha --timeout 5000 && eslint --ext .js --fix",
     "integration": "script/integration.sh",
     "release": "node script/release",
     "dev": "cross-env NODE_PATH=. NODE_ENV=development nodemon server.js",
@@ -18,7 +18,7 @@
     "precompile-assets": "cross-env NODE_ENV=production node script/precompile-assets.js",
     "linkschecker": "NODE_PATH=. NODE_ENV=test node scripts/links-checker.js",
     "cypress": "cypress run",
-    "lint": "eslint --ext .js .",
+    "lint": "eslint --ext .js . --fix",
     "heroku-postbuild": "npm run precompile-assets"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "precompile-assets": "cross-env NODE_ENV=production node script/precompile-assets.js",
     "linkschecker": "NODE_PATH=. NODE_ENV=test node scripts/links-checker.js",
     "cypress": "cypress run",
-    "lint": "standard --fix",
+    "lint": "eslint --ext .js .",
     "heroku-postbuild": "npm run precompile-assets"
   },
   "husky": {
@@ -99,7 +99,10 @@
     "nodemon": "^2.0.4",
     "node-sass": "^4.14.1",
     "simplecrawler": "^1.1.9",
-    "standard": "^12.0.1",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-prettier": "^3.1.3",
+    "prettier": "^2.0.5",
     "supertest": "^4.0.2",
     "supertest-session": "^4.0.0",
     "uglify-js": "^3.8.1",
@@ -108,14 +111,5 @@
   },
   "engines": {
     "node": ">=12 <14"
-  },
-  "standard": {
-    "ignore": [
-      "/js/vendor",
-      "/cypress/integration"
-    ],
-    "env": {
-      "browser": true
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "precompile-assets": "cross-env NODE_ENV=production node script/precompile-assets.js",
     "linkschecker": "NODE_PATH=. NODE_ENV=test node scripts/links-checker.js",
     "cypress": "cypress run",
-    "lint": "eslint --ext .js . --fix",
+    "lint": "eslint . --fix",
     "heroku-postbuild": "npm run precompile-assets"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max_old_space_size=4096' NODE_PATH=. NODE_ENV=production node server.js",
     "bootstrap": "node script/bootstrap",
-    "test": "cross-env NODE_PATH=. NODE_ENV=test mocha --timeout 5000 && eslint --ext .js --fix",
+    "test": "cross-env NODE_PATH=. NODE_ENV=test mocha --timeout 5000 && eslint . --fix",
     "integration": "script/integration.sh",
     "release": "node script/release",
     "dev": "cross-env NODE_PATH=. NODE_ENV=development nodemon server.js",

--- a/routes/apps/index.js
+++ b/routes/apps/index.js
@@ -4,11 +4,13 @@ const categories = require('electron-apps/categories')
 module.exports = (req, res, next) => {
   const context = Object.assign(req.context, {
     apps: apps,
-    categories: categories
+    categories: categories,
   })
 
   if (req.query.category) {
-    const category = categories.find(category => category.slug === req.query.category)
+    const category = categories.find(
+      (category) => category.slug === req.query.category
+    )
 
     if (!category) return next()
 
@@ -16,8 +18,8 @@ module.exports = (req, res, next) => {
     context.currentCategory = req.query.category
   }
 
-  context.categories = categories.map(category => {
-    category.className = (category.slug === req.query.category) ? 'selected' : ''
+  context.categories = categories.map((category) => {
+    category.className = category.slug === req.query.category ? 'selected' : ''
     return category
   })
 

--- a/routes/apps/show.js
+++ b/routes/apps/show.js
@@ -3,12 +3,14 @@ const categories = require('electron-apps/categories')
 const { getPlatformFromFilename } = require('platform-utils')
 
 module.exports = (req, res, next) => {
-  const app = apps.find(app => app.slug === req.params.slug)
+  const app = apps.find((app) => app.slug === req.params.slug)
 
   if (!app) return next()
 
   if (app.category) {
-    app.categorySlug = categories.find(category => category.name === app.category).slug
+    app.categorySlug = categories.find(
+      (category) => category.name === app.category
+    ).slug
   }
 
   const context = Object.assign(req.context, {
@@ -16,20 +18,21 @@ module.exports = (req, res, next) => {
     page: {
       title: `${app.name} | Apps | Electron`,
       url: req.url,
-      description: app.description
-    }
+      description: app.description,
+    },
   })
 
   // attach platform labels like `darwin`, `win32`, and `linux`
   if (app.latestRelease && app.latestRelease.assets) {
-    app.latestRelease.assets.forEach(asset => {
+    app.latestRelease.assets.forEach((asset) => {
       asset.platform = getPlatformFromFilename(asset.name)
     })
   }
 
-  context.page.image = (app.screenshots && app.screenshots.length)
-    ? app.screenshots[0].imageUrl
-    : `${process.env.HOST}/images/apps/${app.icon64}`
+  context.page.image =
+    app.screenshots && app.screenshots.length
+      ? app.screenshots[0].imageUrl
+      : `${process.env.HOST}/images/apps/${app.icon64}`
 
   res.render('apps/show', context)
 }

--- a/routes/blog/index.js
+++ b/routes/blog/index.js
@@ -1,13 +1,13 @@
 const yubikiri = require('yubikiri')
 const BlogPost = require('../../lib/blog')
 
-function hydrateViewModel (blogPost) {
+function hydrateViewModel(blogPost) {
   return yubikiri({
     title: blogPost.title(),
     href: blogPost.href(),
     date: blogPost.date(),
     authors: blogPost.authors(),
-    excerpt: blogPost.excerpt()
+    excerpt: blogPost.excerpt(),
   })
 }
 
@@ -16,7 +16,7 @@ module.exports = async (req, res) => {
   const posts = await Promise.all(blogPosts.map(hydrateViewModel))
   const postsInOrder = posts.sort((a, b) => b.date.localeCompare(a.date))
   Object.assign(req.context, {
-    posts: postsInOrder
+    posts: postsInOrder,
   })
   res.render('blog/index', req.context)
 }

--- a/routes/blog/show.js
+++ b/routes/blog/show.js
@@ -1,14 +1,14 @@
 const yubikiri = require('yubikiri')
 const BlogPost = require('../../lib/blog')
 
-function hydrateViewModel (blogPost) {
+function hydrateViewModel(blogPost) {
   return yubikiri({
     title: blogPost.title(),
     href: blogPost.href(),
     date: blogPost.date(),
     authors: blogPost.authors(),
     excerpt: blogPost.excerpt(),
-    content: blogPost.content()
+    content: blogPost.content(),
   })
 }
 
@@ -29,7 +29,7 @@ module.exports = async (req, res, next) => {
   Object.assign(req.context, {
     post: post,
     layout: 'post',
-    page: { title: `${post.title} | Electron Blog` }
+    page: { title: `${post.title} | Electron Blog` },
   })
   res.render('blog/show', req.context)
 }

--- a/routes/community.js
+++ b/routes/community.js
@@ -1,7 +1,7 @@
 const items = require('awesome-electron')
 const meetups = require('../data/meetups.json')
 
-async function parseItem (item) {
+async function parseItem(item) {
   // categories
   item.isTool = item.category === 'tools'
   item.isBoilerplate = item.category === 'boilerplates'
@@ -17,7 +17,7 @@ async function parseItem (item) {
   return item
 }
 
-async function parseData (items) {
+async function parseData(items) {
   return Promise.all(items.map(parseItem))
 }
 
@@ -25,7 +25,7 @@ module.exports = (req, res) => {
   parseData(items).then((communityData) => {
     const context = Object.assign(req.context, {
       items: communityData,
-      meetups: meetups
+      meetups: meetups,
     })
 
     res.render('community', context)

--- a/routes/docs/category.js
+++ b/routes/docs/category.js
@@ -12,10 +12,10 @@ module.exports = (req, res, next) => {
     { path: 'all', name: 'All the Electron Docs!' },
     { path: 'api', name: 'API' },
     { path: 'development', name: 'Development' },
-    { path: 'tutorial', name: 'Guides' }
+    { path: 'tutorial', name: 'Guides' },
   ]
   const category = req.params.category
-  const selectedCategories = categoryList.filter(cat => cat.path === category)
+  const selectedCategories = categoryList.filter((cat) => cat.path === category)
   let context
 
   if (!selectedCategories.length) return next()
@@ -24,13 +24,13 @@ module.exports = (req, res, next) => {
   if (category === 'all') {
     context = Object.assign(req.context, {
       layout: 'docs',
-      viewingAllDocs: true
+      viewingAllDocs: true,
     })
   } else {
     context = Object.assign(req.context, {
       layout: 'docs',
       processes: processes,
-      category: selectedCategory.name
+      category: selectedCategory.name,
     })
   }
 

--- a/routes/docs/history.js
+++ b/routes/docs/history.js
@@ -11,8 +11,11 @@ module.exports = (req, res, next) => {
   doc.birthTag = historian[filenameKey]
 
   if (doc.birthTag) {
-    doc.releases = req.context.releases.all.filter(release => {
-      return semver.gte(release.data.version, doc.birthTag.replace('v', '')) && !release.isNightly()
+    doc.releases = req.context.releases.all.filter((release) => {
+      return (
+        semver.gte(release.data.version, doc.birthTag.replace('v', '')) &&
+        !release.isNightly()
+      )
     })
   } else {
     doc.releases = []
@@ -23,11 +26,11 @@ module.exports = (req, res, next) => {
     page: {
       title: `${doc.title} Version History | Electron`,
       description: doc.description,
-      url: req.url
+      url: req.url,
     },
     doc: doc,
     viewingDocHistory: true,
-    layout: 'docs'
+    layout: 'docs',
   })
 
   return res.render('docs/history', context)

--- a/routes/docs/index.js
+++ b/routes/docs/index.js
@@ -4,10 +4,10 @@ module.exports = (req, res) => {
   const docsReadme = i18n.docs[req.language]['/docs/README']
 
   const [
+    ,
+    ,
     // Not used: https://github.com/electron/electron/tree/master/docs#official-guides
-    ,
     // Not used: https://github.com/electron/electron/tree/master/docs#faq
-    ,
     // https://github.com/electron/electron/tree/master/docs#guides-and-tutorials
     guides,
     // https://github.com/electron/electron/tree/master/docs#detailed-tutorials
@@ -21,7 +21,7 @@ module.exports = (req, res) => {
     // https://github.com/electron/electron/tree/master/docs#modules-for-the-renderer-process-web-page
     rendererProcModules,
     // https://github.com/electron/electron/tree/master/docs#modules-for-both-processes
-    bothProcModules
+    bothProcModules,
   ] = docsReadme.sections
 
   const context = Object.assign(req.context, {
@@ -31,7 +31,7 @@ module.exports = (req, res) => {
     customDomElements,
     mainProcModules,
     rendererProcModules,
-    bothProcModules
+    bothProcModules,
   })
 
   // Taken from https://github.com/electron/electron/tree/master/docs

--- a/routes/docs/show.js
+++ b/routes/docs/show.js
@@ -4,7 +4,8 @@ const editorCodes = require('crowdin-editor-language-codes')
 module.exports = (req, res, next) => {
   const doc = i18n.docs[req.language][req.path]
   const docEn = req.context.currentLocale.startsWith('en')
-    ? null : i18n.docs['en-US'][req.path]
+    ? null
+    : i18n.docs['en-US'][req.path]
   if (!doc) return next()
 
   // Crowdin's undocumented mystery locale URL format. See https://git.io/vADu0
@@ -22,9 +23,9 @@ module.exports = (req, res, next) => {
     page: {
       title: `${doc.title} | Electron`,
       description: doc.description,
-      url: req.url
+      url: req.url,
     },
-    layout: 'docs'
+    layout: 'docs',
   })
 
   res.render('docs/show', context)

--- a/routes/docs/structures.js
+++ b/routes/docs/structures.js
@@ -10,11 +10,11 @@ module.exports = (req, res, next) => {
 
   let context = Object.assign(req.context, {
     page: {
-      title: 'API Structures | Electron'
+      title: 'API Structures | Electron',
     },
     layout: 'docs',
     processes: processes,
-    category: 'API / API Structures'
+    category: 'API / API Structures',
   })
 
   res.render('docs/structures', context)

--- a/routes/feed/blog.js
+++ b/routes/feed/blog.js
@@ -1,7 +1,7 @@
 const { setupFeed } = require('./mainFeed')
 const BlogPost = require('../../lib/blog')
 
-module.exports = async function feedHandler (req, res, next) {
+module.exports = async function feedHandler(req, res, next) {
   const feed = await setupFeed('blog', await BlogPost.getAll())
 
   if (req.path === '/blog.xml') {

--- a/routes/feed/mainFeed.js
+++ b/routes/feed/mainFeed.js
@@ -5,7 +5,7 @@ const yubikiri = require('yubikiri')
 
 const types = {
   blog: 'blog',
-  releases: 'releases'
+  releases: 'releases',
 }
 
 module.exports.setupFeed = memoize(async (type, items) => {
@@ -20,47 +20,57 @@ module.exports.setupFeed = memoize(async (type, items) => {
       json: 'https://electronjs.org/releases.json',
       atom: 'https://electronjs.org/releases.xml',
       json1: 'https://electronjs.org/blog.json',
-      atom1: 'https://electronjs.org/blog.xml'
-    }
+      atom1: 'https://electronjs.org/blog.xml',
+    },
   })
 
   switch (type) {
     case types.releases:
-      items.forEach(release => {
+      items.forEach((release) => {
         feed.addItem({
           title: `Electron v${release.data.version}`,
           id: `https://electronjs.org/releases#${release.data.version}`,
           date: new Date(release.data.created_at),
           link: release.data.html_url,
-          content: release.data.body_html
+          content: release.data.body_html,
         })
       })
       break
     case types.blog: {
-      const posts = await Promise.all(items.map(post => yubikiri({
-        href: post.href(),
-        title: post.title(),
-        content: post.content(),
-        date: post.date(),
-        author: async () => {
-          const authors = await post.authors()
-          return { name: authors[0] }
-        },
-        image: null // TODO
-      })))
-      posts.sort((a, b) => b.date.localeCompare(a.date)).forEach(post => {
-        feed.addItem({
-          id: `https://electronjs.org${post.href}`,
-          title: post.title,
-          content: post.content,
-          description: description({ content: post.content, endWith: '[...]', limit: 200 }),
-          link: `https://electronjs.org${post.href}`,
-          date: new Date(post.date),
-          published: new Date(post.date),
-          author: post.author,
-          image: post.image || 'https://electronjs.org/images/opengraph.png'
+      const posts = await Promise.all(
+        items.map((post) =>
+          yubikiri({
+            href: post.href(),
+            title: post.title(),
+            content: post.content(),
+            date: post.date(),
+            author: async () => {
+              const authors = await post.authors()
+              return { name: authors[0] }
+            },
+            image: null, // TODO
+          })
+        )
+      )
+      posts
+        .sort((a, b) => b.date.localeCompare(a.date))
+        .forEach((post) => {
+          feed.addItem({
+            id: `https://electronjs.org${post.href}`,
+            title: post.title,
+            content: post.content,
+            description: description({
+              content: post.content,
+              endWith: '[...]',
+              limit: 200,
+            }),
+            link: `https://electronjs.org${post.href}`,
+            date: new Date(post.date),
+            published: new Date(post.date),
+            author: post.author,
+            image: post.image || 'https://electronjs.org/images/opengraph.png',
+          })
         })
-      })
       break
     }
     default:

--- a/routes/feed/releases.js
+++ b/routes/feed/releases.js
@@ -1,6 +1,6 @@
 const { setupFeed } = require('./mainFeed')
 
-module.exports = async function feedHandler (req, res, next) {
+module.exports = async function feedHandler(req, res, next) {
   const feed = await setupFeed('releases', req.context.releases.all)
 
   if (req.path === '/releases.xml') {

--- a/routes/home.js
+++ b/routes/home.js
@@ -13,7 +13,7 @@ module.exports = (req, res) => {
 
   const context = Object.assign(req.context, {
     companies: featuredCompanies,
-    apps
+    apps,
   })
 
   // Reset to 'home' to restore homepage

--- a/routes/languages/proxy.js
+++ b/routes/languages/proxy.js
@@ -6,7 +6,7 @@ const apiWhitelist = [
   '/language-status',
   '/info',
   '/download-glossary',
-  '/export-file'
+  '/export-file',
 ]
 
 module.exports = (req, res, next) => {
@@ -16,7 +16,7 @@ module.exports = (req, res, next) => {
   if (req.method !== 'GET') {
     return res.status(405).json(`${req.method} not allowed`)
   }
-  if (!(apiWhitelist.find((path) => path === url.parse(req.url).pathname))) {
+  if (!apiWhitelist.find((path) => path === url.parse(req.url).pathname)) {
     return res.status(404).render('404', req.context)
   }
   return createProxyMiddleware({
@@ -28,10 +28,10 @@ module.exports = (req, res, next) => {
       newPath.pathname = newPath.pathname.replace('/crowdin', '')
       Object.assign(newPath.query, {
         key: process.env.CROWDIN_KEY,
-        json: true
+        json: true,
       })
       newPath.search = null
       return url.format(newPath)
-    }
+    },
   })(req, res, next)
 }

--- a/routes/userland/index.js
+++ b/routes/userland/index.js
@@ -4,7 +4,7 @@ const path = require('path')
 module.exports = (req, res) => {
   const categories = requireDir(path.join(__dirname, '../../data/userland'))
   const context = Object.assign(req.context, {
-    categories: categories
+    categories: categories,
   })
 
   res.render('userland/index', context)

--- a/routes/userland/show.js
+++ b/routes/userland/show.js
@@ -19,13 +19,10 @@ module.exports = (req, res, next) => {
       'ember-tomster',
       'gitter-badger',
       'invalid-email-address',
-      'waffle-iron'
+      'waffle-iron',
     ]
   } else if (report.isnpmUser) {
-    blacklist = [
-      'uupaa',
-      'etc-etc-etc'
-    ]
+    blacklist = ['uupaa', 'etc-etc-etc']
   }
 
   const context = Object.assign(req.context, {
@@ -33,8 +30,8 @@ module.exports = (req, res, next) => {
     items: report.collection,
     blacklist: blacklist,
     page: {
-      title: `${report.title} | Electron`
-    }
+      title: `${report.title} | Electron`,
+    },
   })
 
   res.render('userland/show', context)

--- a/scripts/add-code-block-buttons.js
+++ b/scripts/add-code-block-buttons.js
@@ -1,18 +1,18 @@
 const ClipboardJS = require('clipboard')
 const clipboard = new ClipboardJS('.btn-clipboard', {
   // strip leading console $ from copied codeblocks
-  text: trigger => {
+  text: (trigger) => {
     const codeBlockID = trigger.getAttribute('data-clipboard-target').substr(1)
     let codeBlock = document.getElementById(codeBlockID).textContent
 
     return codeBlock.replace(/^\$\W*/gm, '')
-  }
+  },
 })
 
-clipboard.on('success', e => e.clearSelection())
+clipboard.on('success', (e) => e.clearSelection())
 
-module.exports = function copyCodeToClipBoard () {
-  document.querySelectorAll(`code.hljs`).forEach(code => {
+module.exports = function copyCodeToClipBoard() {
+  document.querySelectorAll(`code.hljs`).forEach((code) => {
     const id = `_${Math.random().toString(36).substr(5)}`
     code.id = id
 
@@ -24,8 +24,16 @@ module.exports = function copyCodeToClipBoard () {
     // add launch button if fiddle is specified
     if (code.dataset.fiddleUrl) {
       const launchButton = document.createElement('button')
-      launchButton.classList.add('btn-launch', 'tooltipped', 'tooltipped-n', 'float-left')
-      launchButton.setAttribute('aria-label', window.localized.fiddle_launch_button.launch_in_fiddle)
+      launchButton.classList.add(
+        'btn-launch',
+        'tooltipped',
+        'tooltipped-n',
+        'float-left'
+      )
+      launchButton.setAttribute(
+        'aria-label',
+        window.localized.fiddle_launch_button.launch_in_fiddle
+      )
       launchButton.setAttribute('data-fiddle-url', code.dataset.fiddleUrl)
       launchButton.innerHTML = window.localized.fiddle_launch_button.launch
       buttonGroup.appendChild(launchButton)
@@ -33,30 +41,43 @@ module.exports = function copyCodeToClipBoard () {
 
     // add clipboard button
     const copyButton = document.createElement('button')
-    copyButton.classList.add('btn-clipboard', 'tooltipped', 'tooltipped-n', 'float-left')
-    copyButton.setAttribute('aria-label', window.localized.clipboard.copy_to_clipboard)
+    copyButton.classList.add(
+      'btn-clipboard',
+      'tooltipped',
+      'tooltipped-n',
+      'float-left'
+    )
+    copyButton.setAttribute(
+      'aria-label',
+      window.localized.clipboard.copy_to_clipboard
+    )
     copyButton.setAttribute('data-clipboard-target', `#${id}`)
     copyButton.innerHTML = window.localized.clipboard.copy
     buttonGroup.appendChild(copyButton)
   })
 
   // launch button listeners
-  document.querySelectorAll('.btn-launch').forEach(button => {
-    button.addEventListener('mouseout', e => {
+  document.querySelectorAll('.btn-launch').forEach((button) => {
+    button.addEventListener('mouseout', (e) => {
       e.target.blur()
     })
-    button.addEventListener('click', e => {
-      window.open(`https://fiddle.electronjs.org/launch?target=${e.target.dataset.fiddleUrl}`)
+    button.addEventListener('click', (e) => {
+      window.open(
+        `https://fiddle.electronjs.org/launch?target=${e.target.dataset.fiddleUrl}`
+      )
     })
   })
 
   // clipboard button listeners
-  document.querySelectorAll('.btn-clipboard').forEach(button => {
-    button.addEventListener('mouseout', e => {
-      e.target.setAttribute('aria-label', window.localized.clipboard.copy_to_clipboard)
+  document.querySelectorAll('.btn-clipboard').forEach((button) => {
+    button.addEventListener('mouseout', (e) => {
+      e.target.setAttribute(
+        'aria-label',
+        window.localized.clipboard.copy_to_clipboard
+      )
       e.target.blur()
     })
-    button.addEventListener('click', e => {
+    button.addEventListener('click', (e) => {
       e.target.setAttribute('aria-label', window.localized.clipboard.copied)
     })
   })

--- a/scripts/anchor-links.js
+++ b/scripts/anchor-links.js
@@ -1,23 +1,23 @@
 // @ts-check
 
-module.exports = function setupAnchorLinks () {
+module.exports = function setupAnchorLinks() {
   /**
    * @param {string} id
    */
-  function anchorForId (id) {
+  function anchorForId(id) {
     const anchor = document.createElement('a')
     anchor.className = 'header-link'
     anchor.href = '#' + id
     anchor.innerHTML = "<span class='octicon octicon-link'></span>"
     anchor.title = 'Permalink'
     return anchor
-  };
+  }
 
   /**
    * @param {string | number} level
    * @param {Element} containingElement
    */
-  function linkifyAnchors (level, containingElement) {
+  function linkifyAnchors(level, containingElement) {
     const headers = containingElement.getElementsByTagName('h' + level)
     for (let h = 0; h < headers.length; h++) {
       const header = headers[h]
@@ -26,7 +26,7 @@ module.exports = function setupAnchorLinks () {
         header.appendChild(anchorForId(header.id))
       }
     }
-  };
+  }
 
   const contentBlock = document.getElementsByClassName('docs')[0]
   if (!contentBlock) {

--- a/scripts/apply-active-class-to-active-links.js
+++ b/scripts/apply-active-class-to-active-links.js
@@ -1,13 +1,15 @@
 const escapeRegExp = require('lodash/escapeRegExp')
 
-module.exports = function applyActiveClassToActiveLinks () {
+module.exports = function applyActiveClassToActiveLinks() {
   const topPath = `/${location.pathname.split('/')[1]}`
 
   // homepage
   if (!topPath.length) return
 
-  document.querySelectorAll(`nav a`).forEach(a => {
-    const href = escapeRegExp(a.getAttribute('data-href-match') || a.getAttribute('href'))
+  document.querySelectorAll(`nav a`).forEach((a) => {
+    const href = escapeRegExp(
+      a.getAttribute('data-href-match') || a.getAttribute('href')
+    )
     let regexCheck = new RegExp(`^${href}/?.*?`)
     if (regexCheck.test(topPath)) {
       a.classList.add('active')

--- a/scripts/create-filter-list.js
+++ b/scripts/create-filter-list.js
@@ -13,10 +13,17 @@ class FilterList {
     this.input = input
     this.index = this.buildIndex(list)
     this.referenceList = list.cloneNode(true)
-    this.referenceList.querySelectorAll('img[data-src]').forEach(lazyLoadImages.addImage)
-    this.totalAppCount = this.referenceList.querySelectorAll('.listed-app').length
+    this.referenceList
+      .querySelectorAll('img[data-src]')
+      .forEach(lazyLoadImages.addImage)
+    this.totalAppCount = this.referenceList.querySelectorAll(
+      '.listed-app'
+    ).length
 
-    this.input.addEventListener('input', debounce((evt) => this.search(evt.target.value), 250))
+    this.input.addEventListener(
+      'input',
+      debounce((evt) => this.search(evt.target.value), 250)
+    )
     // trigger a search, in case there is an existing value in the text input
     this.search(this.input.value)
   }
@@ -46,9 +53,13 @@ class FilterList {
       newList = this.referenceList.cloneNode(false)
       results.forEach((result) => {
         // Clone from existing list if it exists
-        let node = existingList.querySelector(`[data-search-id="${result.ref}"]`)
+        let node = existingList.querySelector(
+          `[data-search-id="${result.ref}"]`
+        )
         if (!node) {
-          node = this.referenceList.querySelector(`[data-search-id="${result.ref}"]`)
+          node = this.referenceList.querySelector(
+            `[data-search-id="${result.ref}"]`
+          )
         }
         const clone = node.cloneNode(true)
         newList.appendChild(clone)
@@ -94,12 +105,25 @@ class FilterList {
 
   docForEntry(id, entry) {
     const name = entry.querySelector('.listed-app-name').textContent
-    const description = entry.querySelector('.listed-app-description').textContent
-    const addDateSelector = entry.querySelector('.listed-app-add-date [data-date]')
-    const addDate = addDateSelector != null ? addDateSelector.getAttribute('data-date') : undefined;
-    const releaseDateSelector = entry.querySelector('.listed-app-release-date [data-date]')
-    const releaseDate = releaseDateSelector != null ? releaseDateSelector.getAttribute('data-date') : undefined;
-    const keywords = entry.querySelector('.listed-app-keywords').textContent.split(',')
+    const description = entry.querySelector('.listed-app-description')
+      .textContent
+    const addDateSelector = entry.querySelector(
+      '.listed-app-add-date [data-date]'
+    )
+    const addDate =
+      addDateSelector != null
+        ? addDateSelector.getAttribute('data-date')
+        : undefined
+    const releaseDateSelector = entry.querySelector(
+      '.listed-app-release-date [data-date]'
+    )
+    const releaseDate =
+      releaseDateSelector != null
+        ? releaseDateSelector.getAttribute('data-date')
+        : undefined
+    const keywords = entry
+      .querySelector('.listed-app-keywords')
+      .textContent.split(',')
 
     return { id, name, description, addDate, releaseDate, keywords }
   }

--- a/scripts/docs-language-toggle.js
+++ b/scripts/docs-language-toggle.js
@@ -1,15 +1,21 @@
 module.exports = () => {
   // don't add any listener if there isn't at least 1 non-english section
-  if (document.querySelectorAll('.docs div.sub-section:not([data-lang="en-US"])').length > 0) {
+  if (
+    document.querySelectorAll('.docs div.sub-section:not([data-lang="en-US"])')
+      .length > 0
+  ) {
     const toggles = Array.from(document.querySelectorAll('.docs .en-toggle'))
-    toggles.forEach(toggle => {
+    toggles.forEach((toggle) => {
       toggle.onclick = (e) => {
         let el = e.target
-        while (el) { // find parent div
+        while (el) {
+          // find parent div
           if (el.matches('div.sub-section')) break
           el = el.parentElement
         }
-        const otherEl = document.querySelector(`[data-name="${el.dataset.name}"].hidden`)
+        const otherEl = document.querySelector(
+          `[data-name="${el.dataset.name}"].hidden`
+        )
         if (otherEl) {
           otherEl.classList.remove('hidden')
           el.classList.add('hidden')

--- a/scripts/fix-platform-labels.js
+++ b/scripts/fix-platform-labels.js
@@ -2,8 +2,8 @@
 
 const labels = ['macOS', 'Linux', 'Windows']
 
-module.exports = function fixPlatformLabels () {
-  document.querySelectorAll('em').forEach(em => {
+module.exports = function fixPlatformLabels() {
+  document.querySelectorAll('em').forEach((em) => {
     if (labels.includes(em.textContent)) {
       em.classList.add('platform-label')
     }

--- a/scripts/get-localized-strings.js
+++ b/scripts/get-localized-strings.js
@@ -6,12 +6,13 @@
 
 const setProp = require('lodash/set')
 
-module.exports = function getLocalizedString () {
-  window.localized = Array.from(document.querySelectorAll('meta[name^="localized"]'))
-    .reduce((acc, el) => {
-      const key = el.getAttribute('name').replace('localized.', '')
-      const val = el.getAttribute('content')
-      setProp(acc, key, val)
-      return acc
-    }, {})
+module.exports = function getLocalizedString() {
+  window.localized = Array.from(
+    document.querySelectorAll('meta[name^="localized"]')
+  ).reduce((acc, el) => {
+    const key = el.getAttribute('name').replace('localized.', '')
+    const val = el.getAttribute('content')
+    setProp(acc, key, val)
+    return acc
+  }, {})
 }

--- a/scripts/install-toggle.js
+++ b/scripts/install-toggle.js
@@ -1,8 +1,8 @@
-module.exports = function installToggle () {
+module.exports = function installToggle() {
   /**
    * @param {HTMLButtonElement} el
    */
-  function initializeToggler (el) {
+  function initializeToggler(el) {
     el.addEventListener('click', () => {
       const targetAttrib = el.getAttribute('data-toggle-target')
       const targets = document.querySelectorAll(targetAttrib)

--- a/scripts/kb-shortcut-dialog.js
+++ b/scripts/kb-shortcut-dialog.js
@@ -1,4 +1,4 @@
-module.exports = function installKbShortcutDialog () {
+module.exports = function installKbShortcutDialog() {
   // Get the modal
   const modal = document.getElementById('kb-shortcut-dialog')
 
@@ -6,33 +6,45 @@ module.exports = function installKbShortcutDialog () {
   const span = modal.getElementsByClassName('close')[0]
 
   // When the user types ?, open the modal
-  window.addEventListener('keydown', event => {
-    if (event.key === '?') {
-      if (event.target === null || event.target.tagName !== 'INPUT') {
-        modal.style.display = 'block'
-        event.stopImmediatePropagation()
-        event.preventDefault()
+  window.addEventListener(
+    'keydown',
+    (event) => {
+      if (event.key === '?') {
+        if (event.target === null || event.target.tagName !== 'INPUT') {
+          modal.style.display = 'block'
+          event.stopImmediatePropagation()
+          event.preventDefault()
+        }
       }
-    }
 
-    if (modal.style.display === 'block') {
-      if (event.keyCode === 27) {
-        modal.style.display = 'none'
-        event.stopImmediatePropagation()
-        event.preventDefault()
+      if (modal.style.display === 'block') {
+        if (event.keyCode === 27) {
+          modal.style.display = 'none'
+          event.stopImmediatePropagation()
+          event.preventDefault()
+        }
       }
-    }
-  }, true)
+    },
+    true
+  )
 
   // When the user clicks anywhere outside of the modal, close it
-  window.addEventListener('click', (ev) => {
-    if (ev.target === modal) {
-      modal.style.display = 'none'
-    }
-  }, true)
+  window.addEventListener(
+    'click',
+    (ev) => {
+      if (ev.target === modal) {
+        modal.style.display = 'none'
+      }
+    },
+    true
+  )
 
   // When the user clicks on <span> (x), close the modal
-  span.addEventListener('click', () => {
-    modal.style.display = 'none'
-  }, true)
+  span.addEventListener(
+    'click',
+    () => {
+      modal.style.display = 'none'
+    },
+    true
+  )
 }

--- a/scripts/language-selector.js
+++ b/scripts/language-selector.js
@@ -1,5 +1,5 @@
-module.exports = function languageTooltip () {
-  function measureAndSetHeight (el) {
+module.exports = function languageTooltip() {
+  function measureAndSetHeight(el) {
     const height = langHeaderMenu.scrollHeight
     el.style.height = `${height}px`
   }
@@ -21,9 +21,11 @@ module.exports = function languageTooltip () {
     }
   })
 
-  const languageButton = document.querySelector('.site-header-nav .lang-select-button')
+  const languageButton = document.querySelector(
+    '.site-header-nav .lang-select-button'
+  )
   if (languageButton) {
-    languageButton.addEventListener('click', evt => {
+    languageButton.addEventListener('click', (evt) => {
       if (!evt.ctrlKey && !evt.metaKey) {
         evt.preventDefault()
         toggleHeaderMenu()

--- a/scripts/lazy-load-images.js
+++ b/scripts/lazy-load-images.js
@@ -1,15 +1,17 @@
 const throttle = require('lodash/throttle')
 
-function inViewport (element) {
+function inViewport(element) {
   const { top, right, bottom, left } = element.getBoundingClientRect()
-  return bottom > 0 &&
-      window.innerWidth - left > 0 &&
-      window.innerHeight - top > 0 &&
-      right > 0
+  return (
+    bottom > 0 &&
+    window.innerWidth - left > 0 &&
+    window.innerHeight - top > 0 &&
+    right > 0
+  )
 }
 
 module.exports = function () {
-  ['scroll', 'resize', 'load'].forEach(event =>
+  ;['scroll', 'resize', 'load'].forEach((event) =>
     window.addEventListener(event, updateImages)
   )
 
@@ -20,15 +22,15 @@ module.exports = function () {
 
 let images = []
 
-const addImage = module.exports.addImage = function (image) {
+const addImage = (module.exports.addImage = function (image) {
   // abort if this element has previously entered the viewport
   if (!image.dataset.src) return
 
   images.push(image)
   updateImages()
-}
+})
 
-function loadImage (image) {
+function loadImage(image) {
   // abort if this element has entered the viewport after added to the list
   if (!image.dataset.src) return
 
@@ -44,12 +46,12 @@ function loadImage (image) {
   }
 }
 
-const updateImages = module.exports.updateImages = throttle(() => {
-  images = images.filter(image => {
+const updateImages = (module.exports.updateImages = throttle(() => {
+  images = images.filter((image) => {
     if (inViewport(image)) {
       loadImage(image)
       return false // remove from unseen photos
     }
     return true // keep in unseen photos
   })
-}, 100)
+}, 100))

--- a/scripts/links-checker.js
+++ b/scripts/links-checker.js
@@ -13,11 +13,17 @@ crawler.addFetchCondition((queueItem, referrerQueueItem, cb) => {
 
 crawler.discoverResources = (buffer, queueItem) => {
   const $ = cheerio.load(buffer.toString('utf8'))
-  return $('a[href]').get().map((elem) => $(elem).attr('href'))
+  return $('a[href]')
+    .get()
+    .map((elem) => $(elem).attr('href'))
 }
 
 crawler.on('fetch404', (queueItem, response) => {
-  console.warn(`ERROR(404) fetching ${queueItem.path} (referrer: ${queueItem.referrer.replace(host, '')})`)
+  console.warn(
+    `ERROR(404) fetching ${
+      queueItem.path
+    } (referrer: ${queueItem.referrer.replace(host, '')})`
+  )
 })
 
 crawler.on('complete', () => {

--- a/scripts/platform-specific-content.js
+++ b/scripts/platform-specific-content.js
@@ -9,14 +9,14 @@
 
 const { getPlatformFromUserAgent } = require('platform-utils')
 
-module.exports = function platformSpecificContent () {
+module.exports = function platformSpecificContent() {
   const platform = getPlatformFromUserAgent()
   const elements = Array.from(document.querySelectorAll(`.${platform}-only`))
 
-  elements.forEach(el => {
+  elements.forEach((el) => {
     const classes = Array.from(el.classList)
     console.log(classes)
-    let displayType = classes.find(c => c.startsWith('display-'))
+    let displayType = classes.find((c) => c.startsWith('display-'))
     displayType = displayType ? displayType.replace('display-', '') : 'block'
     el.style.display = displayType
   })

--- a/scripts/remove-scheme-from-link-text.js
+++ b/scripts/remove-scheme-from-link-text.js
@@ -2,6 +2,7 @@ const schemeless = require('schemeless')
 
 module.exports = function () {
   document.querySelectorAll('a[href^=http]').forEach(function (a) {
-    if (a.textContent.startsWith('http')) a.textContent = schemeless(a.textContent)
+    if (a.textContent.startsWith('http'))
+      a.textContent = schemeless(a.textContent)
   })
 }

--- a/scripts/screenshot-thumb-selector.js
+++ b/scripts/screenshot-thumb-selector.js
@@ -8,7 +8,7 @@ module.exports = function () {
     return
   }
 
-  function chooseThumb (thumbImg) {
+  function chooseThumb(thumbImg) {
     return function () {
       activeScreenshot.src = thumbImg.src
       activeScreenshot.alt = thumbImg.alt

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -3,20 +3,25 @@ const instantsearch = require('instantsearch.js')
 const pluralize = require('pluralize')
 const searchWithYourKeyboard = require('search-with-your-keyboard')
 const searches = {}
-const types = [{
-  name: 'api',
-  path: '/docs/api'
-}, {
-  name: 'tutorial',
-  path: '/docs/tutorial'
-}, {
-  name: 'package',
-  path: '/community'
-}, {
-  name: 'app',
-  path: '/apps'
-}]
-const typeNames = types.map(type => type.name)
+const types = [
+  {
+    name: 'api',
+    path: '/docs/api',
+  },
+  {
+    name: 'tutorial',
+    path: '/docs/tutorial',
+  },
+  {
+    name: 'package',
+    path: '/community',
+  },
+  {
+    name: 'app',
+    path: '/apps',
+  },
+]
+const typeNames = types.map((type) => type.name)
 
 module.exports = () => {
   buildMultiSearch()
@@ -25,12 +30,12 @@ module.exports = () => {
   searchWithYourKeyboard('#search-input', '.ais-hits--item')
 }
 
-function buildSearch (type, isPrimarySearch = false, searches) {
+function buildSearch(type, isPrimarySearch = false, searches) {
   const opts = {
     appId: 'L9LD9GHGQJ',
     apiKey: '24e7e99910a15eb5d9d93531e5682370',
     indexName: pluralize(type),
-    advancedSyntax: true
+    advancedSyntax: true,
   }
 
   // the primary search delegates queries to secondary searches
@@ -38,14 +43,14 @@ function buildSearch (type, isPrimarySearch = false, searches) {
     // sync search input with query param in address bar
     opts.routing = {
       stateMapping: {
-        stateToRoute (UIstate) {
+        stateToRoute(UIstate) {
           // Use 'q' parameter in route instead of 'query'
           return { q: UIstate.query }
         },
-        routeToState (routeState) {
+        routeToState(routeState) {
           return { query: routeState.q }
-        }
-      }
+        },
+      },
     }
 
     opts.searchFunction = (helper) => {
@@ -53,13 +58,16 @@ function buildSearch (type, isPrimarySearch = false, searches) {
 
       // should search be isolated to a specific type?
       // e.g. `is:app foo` or `app:foo`
-      const isolatedType = typeNames.find(typeName => {
-        return query.includes(`is:${typeName}`) || query.includes(`${typeName}:`)
+      const isolatedType = typeNames.find((typeName) => {
+        return (
+          query.includes(`is:${typeName}`) || query.includes(`${typeName}:`)
+        )
       })
 
       // hide hit containers if a specific type is isolated
-      typeNames.forEach(typeName => {
-        const display = (!isolatedType || (isolatedType === typeName)) ? 'block' : 'none'
+      typeNames.forEach((typeName) => {
+        const display =
+          !isolatedType || isolatedType === typeName ? 'block' : 'none'
         document.getElementById(`${typeName}-hits`).style.display = display
       })
 
@@ -72,10 +80,11 @@ function buildSearch (type, isPrimarySearch = false, searches) {
 
       // hide the primary search results' container if no results
       const primarySearch = searches[types[0].name]
-      if (primarySearch && primarySearch.helper) primarySearch.helper.once('result', onResult)
+      if (primarySearch && primarySearch.helper)
+        primarySearch.helper.once('result', onResult)
 
       // delegate query to secondary searches
-      types.slice(1).forEach(type => {
+      types.slice(1).forEach((type) => {
         const search = searches[type.name]
         if (search && search.helper) {
           search.helper.once('result', onResult)
@@ -89,9 +98,10 @@ function buildSearch (type, isPrimarySearch = false, searches) {
   }
 
   // https://community.algolia.com/algoliasearch-helper-js/reference.html#AlgoliaSearchHelper#event:search
-  function onResult (results, state) {
+  function onResult(results, state) {
     const id = `${state.index.replace(/s$/, '')}-hits`
-    document.getElementById(id).style.display = (results.hits.length === 0) ? 'none' : 'block'
+    document.getElementById(id).style.display =
+      results.hits.length === 0 ? 'none' : 'block'
   }
 
   const search = instantsearch(opts)
@@ -101,15 +111,15 @@ function buildSearch (type, isPrimarySearch = false, searches) {
       container: `#${type}-hits`,
       templates: {
         // empty: 'No results',
-        item: templates[type]
+        item: templates[type],
       },
       transformData: {
-        item: data => {
+        item: (data) => {
           // useful for viewing template context:
           // console.log(`${type} data`, data)
           return data
-        }
-      }
+        },
+      },
     })
   )
 
@@ -118,7 +128,7 @@ function buildSearch (type, isPrimarySearch = false, searches) {
       instantsearch.widgets.searchBox({
         container: '#search-input',
         placeholder: `Search Electron ${pluralize(type)}`,
-        autofocus: false
+        autofocus: false,
       })
     )
   }
@@ -136,52 +146,55 @@ function buildSearch (type, isPrimarySearch = false, searches) {
   search.start()
 }
 
-function determineOrder () {
-  types.forEach(type => {
-    if (location.pathname === type.path) document.getElementById(`${type.name}-hits`).className = 'first'
+function determineOrder() {
+  types.forEach((type) => {
+    if (location.pathname === type.path)
+      document.getElementById(`${type.name}-hits`).className = 'first'
   })
 }
 
-function buildMultiSearch () {
-  types.forEach(type => {
+function buildMultiSearch() {
+  types.forEach((type) => {
     buildSearch(type.name, type.name === types[0].name, searches)
   })
 }
 
-function buildSearchUIHandlers () {
+function buildSearchUIHandlers() {
   if (location.search.includes('query=')) showHits()
 
   let navInput = document.querySelector('.nav-search')
   let hits = document.getElementById('hits')
-  navInput.addEventListener('input', e => {
+  navInput.addEventListener('input', (e) => {
     navInput.value ? showHits() : hideHits()
   })
-  navInput.addEventListener('focus', e => {
+  navInput.addEventListener('focus', (e) => {
     navInput.value ? showHits() : hideHits()
   })
-  window.addEventListener('click', e => {
+  window.addEventListener('click', (e) => {
     if (!navInput.value) return hideHits()
 
-    e.target === navInput || checkIfChild(hits, e.target) ? showHits() : hideHits()
+    e.target === navInput || checkIfChild(hits, e.target)
+      ? showHits()
+      : hideHits()
   })
 
   // window.addEventListener('click', e => {
   //   if (e.target === document.querySelector('.dialog-button')) document.querySelector('#search-hint-dialog').style.display = 'none'
   // })
 
-  function showHits () {
+  function showHits() {
     document.getElementById('hits').style.display = 'block'
     // document.getElementById('search-hint').style.display="none"
     // document.querySelector('#search-hint-dialog').style.display = "none"
   }
 
-  function hideHits () {
+  function hideHits() {
     document.getElementById('hits').style.display = 'none'
     // document.getElementById('search-hint').style.display = "inline"
   }
 
-  function checkIfChild (parentElement, checkElement) {
-    parentElement.childNodes.forEach(node => {
+  function checkIfChild(parentElement, checkElement) {
+    parentElement.childNodes.forEach((node) => {
       if (node === checkElement) return true
       checkIfChild(node, checkElement)
     })

--- a/scripts/sticky-app-meta.js
+++ b/scripts/sticky-app-meta.js
@@ -2,7 +2,7 @@ module.exports = function () {
   const appMeta = document.querySelector('.app-meta')
   if (!appMeta) return
 
-  function setSticky () {
+  function setSticky() {
     if (appMeta.getBoundingClientRect().height < window.innerHeight) {
       appMeta.classList.add('sticky')
     } else {

--- a/scripts/update-app-download-links.js
+++ b/scripts/update-app-download-links.js
@@ -3,13 +3,13 @@ const { getPlatformFromUserAgent, getPlatformLabel } = require('platform-utils')
 // Emphasize app download links for the visitor's OS (darwin|linux|win32)
 // Platform is inferred from user agent
 
-module.exports = function updateAppDownloadLinks () {
+module.exports = function updateAppDownloadLinks() {
   const links = Array.from(document.querySelectorAll('a.app-download'))
   // No downloads links found on the page.
   if (!links.length) return
 
   const platform = getPlatformFromUserAgent()
-  const matches = links.filter(link => link.classList.contains(platform))
+  const matches = links.filter((link) => link.classList.contains(platform))
 
   if (!matches.length) {
     // No downloads found for the detected OS, probably android/ios
@@ -17,7 +17,7 @@ module.exports = function updateAppDownloadLinks () {
     links[0].parentNode.style.display = 'none'
   }
 
-  links.forEach(link => {
+  links.forEach((link) => {
     link.style.display = link.classList.contains(platform)
       ? 'inline-block'
       : 'none'

--- a/scripts/update-demo-app-download-link.js
+++ b/scripts/update-demo-app-download-link.js
@@ -1,6 +1,6 @@
 const { getPlatformFromUserAgent, getPlatformLabel } = require('platform-utils')
 
-module.exports = function updateDemoAppDownloadLink () {
+module.exports = function updateDemoAppDownloadLink() {
   if (!document.querySelector('#download-latest-release')) return
   const platform = getPlatformFromUserAgent()
 
@@ -13,12 +13,13 @@ module.exports = function updateDemoAppDownloadLink () {
   if (platform === 'win32') assetName = 'ElectronAPIDemosSetup.exe'
   if (platform === 'linux') assetName = 'electron-api-demos-linux.zip'
 
-  document.querySelector('#download-latest-release')
+  document
+    .querySelector('#download-latest-release')
     .setAttribute('href', releaseServer + assetName)
 
-  document.querySelector('#download-latest-release .label')
-    .textContent = 'Download for ' + getPlatformLabel(platform)
+  document.querySelector('#download-latest-release .label').textContent =
+    'Download for ' + getPlatformLabel(platform)
 
-  document.querySelector('#download-alternatives')
-    .style.display = 'inline-block'
+  document.querySelector('#download-alternatives').style.display =
+    'inline-block'
 }

--- a/server.js
+++ b/server.js
@@ -39,26 +39,33 @@ hbs.registerAsyncHelper('octicon', async (data, cb) => {
   const { name, className, ariaLabel, width, height } = data.hash
 
   if (data.hash.class) {
-    return console.error(`ERROR(Octicons Helper): Use 'className' instead of 'class'.`)
+    return console.error(
+      `ERROR(Octicons Helper): Use 'className' instead of 'class'.`
+    )
   }
 
   if (name === undefined) {
-    return console.error('ERROR(Octicons Helper): Name is required field in octicon helper.')
+    return console.error(
+      'ERROR(Octicons Helper): Name is required field in octicon helper.'
+    )
   }
 
   const htmlSVG = await getOcticons(name, className, width, height, ariaLabel)
   return cb(new hbs.SafeString(htmlSVG))
 })
-app.engine('html', hbs.express4({
-  defaultLayout: path.join(__dirname, '/views/layouts/main.html'),
-  extname: '.html',
-  layoutsDir: path.join(__dirname, '/views/layouts'),
-  partialsDir: path.join(__dirname, '/views/partials'),
-  onCompile: function (exhbs, source, filename) {
-    var options = { preventIndent: true }
-    return exhbs.handlebars.compile(source, options)
-  }
-}))
+app.engine(
+  'html',
+  hbs.express4({
+    defaultLayout: path.join(__dirname, '/views/layouts/main.html'),
+    extname: '.html',
+    layoutsDir: path.join(__dirname, '/views/layouts'),
+    partialsDir: path.join(__dirname, '/views/partials'),
+    onCompile: function (exhbs, source, filename) {
+      var options = { preventIndent: true }
+      return exhbs.handlebars.compile(source, options)
+    },
+  })
+)
 
 // Middleware
 app.set('view engine', 'html')
@@ -67,22 +74,28 @@ app.use(compression())
 app.use(helmet())
 if (process.env.NODE_ENV === 'production') {
   console.log('Production app detected; serving JS and CSS from disk')
-  app.use(express.static(path.join(__dirname, 'precompiled'), { redirect: false }))
+  app.use(
+    express.static(path.join(__dirname, 'precompiled'), { redirect: false })
+  )
 } else {
   console.log('Dev app detected; compiling JS and CSS in memory')
   app.use(sass())
   app.use('/scripts/index.js', browserify('scripts/index.js'))
 }
-app.get('/service-worker.js', (req, res) => res.sendFile(path.resolve(__dirname, 'scripts', 'service-worker.js')))
+app.get('/service-worker.js', (req, res) =>
+  res.sendFile(path.resolve(__dirname, 'scripts', 'service-worker.js'))
+)
 app.use(cookieParser())
-app.use(requestLanguage({
-  languages: Object.keys(i18n.locales),
-  cookie: {
-    name: 'language',
-    options: { maxAge: 30 * 24 * 60 * 60 * 1000 },
-    url: '/languages/{language}'
-  }
-}))
+app.use(
+  requestLanguage({
+    languages: Object.keys(i18n.locales),
+    cookie: {
+      name: 'language',
+      options: { maxAge: 30 * 24 * 60 * 60 * 1000 },
+      url: '/languages/{language}',
+    },
+  })
+)
 app.use(express.static(path.join(__dirname, 'public'), { redirect: false }))
 app.use('/app-img', express.static(appImgDir, { redirect: false }))
 app.use(slashes(false))
@@ -110,19 +123,33 @@ app.get('/devtron', routes.devtron)
 app.get('/docs', routes.docs.index)
 app.get('/docs/versions', (req, res) => res.redirect(301, '/releases/stable'))
 app.get('/docs/:category', routes.docs.category)
-app.get('/docs/api/breaking-changes', (req, res) => res.redirect(301, '/docs/breaking-changes'))
+app.get('/docs/api/breaking-changes', (req, res) =>
+  res.redirect(301, '/docs/breaking-changes')
+)
 app.get('/docs/api/structures', routes.docs.structures)
 app.get('/docs/*/history', routes.docs.history)
 app.get('/docs/:category/*', routes.docs.show)
-app.get('/docs/latest*', (req, res) => res.redirect(req.path.replace(/^\/docs\/latest/ig, '/docs')))
-app.get('/docs/v0*', (req, res) => res.redirect(req.path.replace(/^\/docs\/v0\.\d+\.\d+/ig, '/docs')))
+app.get('/docs/latest*', (req, res) =>
+  res.redirect(req.path.replace(/^\/docs\/latest/gi, '/docs'))
+)
+app.get('/docs/v0*', (req, res) =>
+  res.redirect(req.path.replace(/^\/docs\/v0\.\d+\.\d+/gi, '/docs'))
+)
 app.get('/docs/tutorial/faq', (req, res) => res.redirect('/docs/faq'))
 app.get('/governance', routes.governance.index)
-app.get('/issues', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/issues'))
-app.get('/issues/new', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/issues/new'))
+app.get('/issues', (req, res) =>
+  res.redirect(301, 'https://github.com/electron/electronjs.org/issues')
+)
+app.get('/issues/new', (req, res) =>
+  res.redirect(301, 'https://github.com/electron/electronjs.org/issues/new')
+)
 app.get('/languages', routes.languages.index)
-app.get('/maintainers/join', (req, res) => res.redirect('https://airtable.com/shrNrpaXIJiRZj6bS'))
-app.get('/pulls', (req, res) => res.redirect(301, 'https://github.com/electron/electronjs.org/pulls'))
+app.get('/maintainers/join', (req, res) =>
+  res.redirect('https://airtable.com/shrNrpaXIJiRZj6bS')
+)
+app.get('/pulls', (req, res) =>
+  res.redirect(301, 'https://github.com/electron/electronjs.org/pulls')
+)
 app.get('/releases', (req, res) => res.redirect(301, '/releases/stable'))
 app.get('/releases/stable', routes.releases.index('stable'))
 app.get('/releases/beta', routes.releases.index('beta'))
@@ -134,7 +161,9 @@ app.get('/userland/*', routes.userland.show)
 app.use('/crowdin', routes.languages.proxy)
 app.use('/donors', routes.donors)
 app.use('/headers/*', routes.headers)
-app.get('/search/:searchIn*?*', (req, res) => res.redirect(req.query.q ? `/?query=${req.query.q}` : `/`))
+app.get('/search/:searchIn*?*', (req, res) =>
+  res.redirect(req.query.q ? `/?query=${req.query.q}` : `/`)
+)
 
 // Generic 404 handler
 app.use(routes._404)

--- a/templates/index.js
+++ b/templates/index.js
@@ -10,5 +10,5 @@ module.exports = {
   app: fs.readFileSync(path.join(__dirname, 'app.html'), 'utf8'),
   api: fs.readFileSync(path.join(__dirname, 'api.html'), 'utf8'),
   package: fs.readFileSync(path.join(__dirname, 'package.html'), 'utf8'),
-  tutorial: fs.readFileSync(path.join(__dirname, 'tutorial.html'), 'utf8')
+  tutorial: fs.readFileSync(path.join(__dirname, 'tutorial.html'), 'utf8'),
 }

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -19,6 +19,8 @@ describe('i18n', () => {
     channels.security.should.not.include('security@electronjs.org')
     channels.code_of_conduct.should.not.include('coc@electronjs.org')
     channels.other.should.not.include('info@electronjs.org')
-    channels.security.should.include('mailto:&#115;&#101;&#99;&#117;&#114;&#105;&#116;&#121;&#64;&#101;&#108;&#101;&#99;&#116;&#114;&#111;&#110;&#106;&#115;&#46;&#111;&#114;&#103;')
+    channels.security.should.include(
+      'mailto:&#115;&#101;&#99;&#117;&#114;&#105;&#116;&#121;&#64;&#101;&#108;&#101;&#99;&#116;&#114;&#111;&#110;&#106;&#115;&#46;&#111;&#114;&#103;'
+    )
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ chai.should()
 chai.use(require('chai-cheerio'))
 const app = require('../server.js')
 
-async function get (route) {
+async function get(route) {
   const res = await supertest(app).get(route)
   const $ = cheerio.load(res.text)
   $.res = Object.assign({}, res)
@@ -28,7 +28,9 @@ describe('electronjs.org', () => {
   describe('feeds', () => {
     test('blog feeds', async () => {
       let res = await supertest(app).get(`/blog.json`)
-      res.headers['content-type'].should.equal('application/json; charset=utf-8')
+      res.headers['content-type'].should.equal(
+        'application/json; charset=utf-8'
+      )
       res.body.title.should.equal('Electron')
       res = await supertest(app).get(`/blog.xml`)
       res.headers['content-type'].should.equal('text/xml; charset=utf-8')
@@ -36,7 +38,9 @@ describe('electronjs.org', () => {
 
     test('releases feeds', async () => {
       let res = await supertest(app).get(`/releases.json`)
-      res.headers['content-type'].should.equal('application/json; charset=utf-8')
+      res.headers['content-type'].should.equal(
+        'application/json; charset=utf-8'
+      )
       res.body.title.should.equal('Electron')
       res = await supertest(app).get(`/releases.xml`)
       res.headers['content-type'].should.equal('text/xml; charset=utf-8')
@@ -55,15 +59,31 @@ describe('electronjs.org', () => {
     // is in place
     test.skip('displays electron version data for latest and beta', async () => {
       const $ = await get('/')
-      $('#electron-version-latest').text().should.match(/npm i -D electron@latest/)
-      $('#electron-version-latest').text().should.match(/Electron\s+\d+\.\d+\.\d+/)
-      $('#electron-version-latest').text().should.match(/Node\s+\d+\.\d+\.\d+/)
-      $('#electron-version-latest').text().should.match(/Chromium\s+\d+\.\d+\.\d+\.\d+/)
+      $('#electron-version-latest')
+        .text()
+        .should.match(/npm i -D electron@latest/)
+      $('#electron-version-latest')
+        .text()
+        .should.match(/Electron\s+\d+\.\d+\.\d+/)
+      $('#electron-version-latest')
+        .text()
+        .should.match(/Node\s+\d+\.\d+\.\d+/)
+      $('#electron-version-latest')
+        .text()
+        .should.match(/Chromium\s+\d+\.\d+\.\d+\.\d+/)
 
-      $('#electron-version-beta').text().should.match(/npm i -D electron@beta/)
-      $('#electron-version-beta').text().should.match(/Electron\s+\d+\.\d+\.\d+/)
-      $('#electron-version-beta').text().should.match(/Node\s+\d+\.\d+\.\d+/)
-      $('#electron-version-beta').text().should.match(/Chromium\s+\d+\.\d+\.\d+\.\d+/)
+      $('#electron-version-beta')
+        .text()
+        .should.match(/npm i -D electron@beta/)
+      $('#electron-version-beta')
+        .text()
+        .should.match(/Electron\s+\d+\.\d+\.\d+/)
+      $('#electron-version-beta')
+        .text()
+        .should.match(/Node\s+\d+\.\d+\.\d+/)
+      $('#electron-version-beta')
+        .text()
+        .should.match(/Chromium\s+\d+\.\d+\.\d+\.\d+/)
     })
 
     // The test is intentionally disabled while the new temporary homepage
@@ -73,25 +93,36 @@ describe('electronjs.org', () => {
       $('header').should.have.class('site-header')
       $('p.jumbotron-lead').should.contain('Build cross-platform desktop apps')
       $('.featured-app-list-item').length.should.equal(5)
-      $('head > title').text().should.match(/^Electron/)
+      $('head > title')
+        .text()
+        .should.match(/^Electron/)
     })
 
     test('displays Code of Conduct link in the footer', async () => {
       const $ = await get('/')
-      $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md"]')
-        .text().should.eq('Code of Conduct')
+      $(
+        'a.footer-nav-item[href="https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md"]'
+      )
+        .text()
+        .should.eq('Code of Conduct')
     })
 
     test('displays Security link in the footer', async () => {
       const $ = await get('/')
-      $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/SECURITY.md"]')
-        .text().should.eq('Security')
+      $(
+        'a.footer-nav-item[href="https://github.com/electron/electron/tree/master/SECURITY.md"]'
+      )
+        .text()
+        .should.eq('Security')
     })
 
     test('displays License link in the footer', async () => {
       const $ = await get('/')
-      $('a.footer-nav-item[href="https://github.com/electron/electron/tree/master/LICENSE"]')
-        .text().should.eq('License')
+      $(
+        'a.footer-nav-item[href="https://github.com/electron/electron/tree/master/LICENSE"]'
+      )
+        .text()
+        .should.eq('License')
     })
   })
 
@@ -111,7 +142,9 @@ describe('electronjs.org', () => {
     test('index has custom title and description meta tags', async () => {
       const $ = await get('/apps')
       $('head > title').text().should.eq('Electron Apps | Electron')
-      $('meta[property="og:description"]').attr('content').should.eq('Apps Built on Electron')
+      $('meta[property="og:description"]')
+        .attr('content')
+        .should.eq('Apps Built on Electron')
     })
 
     test('apps are sorted by date, descending', async () => {
@@ -164,7 +197,9 @@ describe('electronjs.org', () => {
     test('index', async () => {
       const $ = await get('/docs')
       $('header').should.have.class('site-header')
-      $('a[href="/docs/tutorial/development-environment#setting-up-macos"]').should.have.text('Setting up macOS')
+      $(
+        'a[href="/docs/tutorial/development-environment#setting-up-macos"]'
+      ).should.have.text('Setting up macOS')
       $('a[href="/docs/api/auto-updater"]').should.have.text('autoUpdater')
     })
 
@@ -218,7 +253,9 @@ describe('electronjs.org', () => {
     test('uses page title and description', async () => {
       const $ = await get('/docs/api/browser-window')
       $('head > title').text().should.eq('BrowserWindow | Electron')
-      $('meta[property="og:description"]').attr('content').should.eq('Create and control browser windows.')
+      $('meta[property="og:description"]')
+        .attr('content')
+        .should.eq('Create and control browser windows.')
     })
 
     test('docs/all', async () => {
@@ -260,7 +297,11 @@ describe('electronjs.org', () => {
     describe('docs footer', () => {
       test('includes a link to edit the doc on GitHub', async () => {
         const $ = await get('/docs/api/accelerator')
-        $('.propose-change').attr('href').should.eq('https://github.com/electron/electron/tree/master/docs/api/accelerator.md')
+        $('.propose-change')
+          .attr('href')
+          .should.eq(
+            'https://github.com/electron/electron/tree/master/docs/api/accelerator.md'
+          )
       })
 
       test('includes a link to translate the doc on Crowdin', async () => {
@@ -268,7 +309,9 @@ describe('electronjs.org', () => {
           .get('/docs/api/accelerator')
           .set('Cookie', ['language=zh-CN'])
         const $ = cheerio.load(res.text)
-        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/63/en-zhcn')
+        $('.translate-on-crowdin')
+          .attr('href')
+          .should.eq('https://crowdin.com/translate/electron/63/en-zhcn')
       })
 
       test('includes a link to translate the doc on Crowdin for Indonesian', async () => {
@@ -276,7 +319,9 @@ describe('electronjs.org', () => {
           .get('/docs/api/crash-reporter')
           .set('Cookie', ['language=id-ID'])
         const $ = cheerio.load(res.text)
-        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/74/en-id')
+        $('.translate-on-crowdin')
+          .attr('href')
+          .should.eq('https://crowdin.com/translate/electron/74/en-id')
       })
 
       test('includes a link to Crowdin language picker when language is English', async () => {
@@ -286,7 +331,9 @@ describe('electronjs.org', () => {
           .get('/docs/api/browser-view')
           .set('Cookie', ['language=en-US'])
         const $ = cheerio.load(res.text)
-        $('.translate-on-crowdin').attr('href').should.eq('https://crowdin.com/translate/electron/66/en-en')
+        $('.translate-on-crowdin')
+          .attr('href')
+          .should.eq('https://crowdin.com/translate/electron/66/en-en')
       })
 
       test('includes a link to view doc history', async () => {
@@ -310,7 +357,9 @@ describe('electronjs.org', () => {
       $englishSections.length.should.equal($chineseSections.length)
       $chineseSections.each((i, elem) => {
         const name = $(elem).data('name')
-        $(`.docs .sub-section[data-lang="en-US"][data-name="${name}"]`).length.should.be.above(0)
+        $(
+          `.docs .sub-section[data-lang="en-US"][data-name="${name}"]`
+        ).length.should.be.above(0)
       })
     })
 
@@ -351,8 +400,10 @@ describe('electronjs.org', () => {
       const lastPage = parseInt(pages.text().trim(), 10)
       lastPage.should.be.gt(50)
 
-      const titles = $('.release-entry').map((i, el) => $(el).text().trim()).get()
-      titles.forEach(title => {
+      const titles = $('.release-entry')
+        .map((i, el) => $(el).text().trim())
+        .get()
+      titles.forEach((title) => {
         title.should.match(/Electron \d+\.\d+\.\d/)
       })
     })
@@ -366,8 +417,10 @@ describe('electronjs.org', () => {
       const lastPage = parseInt(pages.text().trim(), 10)
       lastPage.should.be.gt(5)
 
-      const titles = $('.release-entry').map((i, el) => $(el).text().trim()).get()
-      titles.forEach(title => {
+      const titles = $('.release-entry')
+        .map((i, el) => $(el).text().trim())
+        .get()
+      titles.forEach((title) => {
         title.should.match(/Electron \d+\.\d+\.\d+-beta\.\d+/)
       })
     })
@@ -381,8 +434,10 @@ describe('electronjs.org', () => {
       const lastPage = parseInt(pages.text().trim(), 10)
       lastPage.should.be.gt(3)
 
-      const titles = $('.release-entry').map((i, el) => $(el).text().trim()).get()
-      titles.forEach(title => {
+      const titles = $('.release-entry')
+        .map((i, el) => $(el).text().trim())
+        .get()
+      titles.forEach((title) => {
         title.should.match(/Electron \d+\.\d+\.\d+-nightly\.\d+/)
       })
     })
@@ -424,7 +479,9 @@ describe('electronjs.org', () => {
       const $ = await get('/community')
       $('h1').text().should.eq('Electron Community')
 
-      const titles = $('h2').map((i, el) => $(el).text()).get()
+      const titles = $('h2')
+        .map((i, el) => $(el).text())
+        .get()
       titles.should.include('Tools')
       titles.should.include('Components')
       titles.should.include('Meetups')
@@ -435,7 +492,9 @@ describe('electronjs.org', () => {
         .get('/community')
         .set('Cookie', ['language=vi-VN'])
       const $ = cheerio.load(res.text)
-      $('.subtron .container-narrow h1').text().should.eq(i18n.website['vi-VN'].community.title)
+      $('.subtron .container-narrow h1')
+        .text()
+        .should.eq(i18n.website['vi-VN'].community.title)
     })
 
     test('/contact redirects to /community', async () => {
@@ -448,24 +507,34 @@ describe('electronjs.org', () => {
   describe('localized strings for client-side code', () => {
     it('sets meta tags for clipboard labels', async () => {
       const $ = await get('/')
-      $('meta[name="localized.clipboard.copy"]').attr('content').should.eq('Copy')
-      $('meta[name="localized.clipboard.copy_to_clipboard"]').attr('content').should.eq('Copy to Clipboard')
+      $('meta[name="localized.clipboard.copy"]')
+        .attr('content')
+        .should.eq('Copy')
+      $('meta[name="localized.clipboard.copy_to_clipboard"]')
+        .attr('content')
+        .should.eq('Copy to Clipboard')
     })
   })
 
   describe('devtron and spectron', () => {
     test('Test existed landing pages', async () => {
       let $ = await get('/devtron')
-      $('.jumbotron-lead .jumbotron-lead-muted').text().should.eq('An Electron DevTools Extension')
+      $('.jumbotron-lead .jumbotron-lead-muted')
+        .text()
+        .should.eq('An Electron DevTools Extension')
       $ = await get('/spectron')
-      $('.jumbotron-lead .jumbotron-lead-muted').text().should.eq('An Electron Testing Framework')
+      $('.jumbotron-lead .jumbotron-lead-muted')
+        .text()
+        .should.eq('An Electron Testing Framework')
     })
   })
 
   describe('electron fiddle', () => {
     test('Fiddle landing page existed', async () => {
       const $ = await get('/fiddle')
-      $('.jumbotron-lead .jumbotron-lead-muted').text().should.eq('The easiest way to get started with Electron')
+      $('.jumbotron-lead .jumbotron-lead-muted')
+        .text()
+        .should.eq('The easiest way to get started with Electron')
     })
   })
 
@@ -518,10 +587,30 @@ describe('electronjs.org', () => {
 
       // valid language query is not redirected (200)
       const langs = [
-        'ar-SA', 'bg-BG', 'cs-CZ', 'de-DE', 'en-US', 'es-ES',
-        'fa-IR', 'fil-PH', 'fr-FR', 'hi-IN', 'id-ID', 'it-IT',
-        'ja-JP', 'ko-KR', 'nl-NL', 'pl-PL', 'pt-BR', 'ru-RU',
-        'th-TH', 'tr-TR', 'uk-UA', 'vi-VN', 'zh-CN', 'zh-TW'
+        'ar-SA',
+        'bg-BG',
+        'cs-CZ',
+        'de-DE',
+        'en-US',
+        'es-ES',
+        'fa-IR',
+        'fil-PH',
+        'fr-FR',
+        'hi-IN',
+        'id-ID',
+        'it-IT',
+        'ja-JP',
+        'ko-KR',
+        'nl-NL',
+        'pl-PL',
+        'pt-BR',
+        'ru-RU',
+        'th-TH',
+        'tr-TR',
+        'uk-UA',
+        'vi-VN',
+        'zh-CN',
+        'zh-TW',
       ]
       for (let lang of langs) {
         res = await supertest(app).get(`/docs/api/browser-window?lang=${lang}`)
@@ -567,19 +656,25 @@ describe('electronjs.org', () => {
     test('redirects /issues to the website repo, for convenience', async () => {
       const res = await supertest(app).get('/issues')
       res.statusCode.should.equal(301)
-      res.headers.location.should.equal('https://github.com/electron/electronjs.org/issues')
+      res.headers.location.should.equal(
+        'https://github.com/electron/electronjs.org/issues'
+      )
     })
 
     test('redirects /issues/new to the website repo, for convenience', async () => {
       const res = await supertest(app).get('/issues/new')
       res.statusCode.should.equal(301)
-      res.headers.location.should.equal('https://github.com/electron/electronjs.org/issues/new')
+      res.headers.location.should.equal(
+        'https://github.com/electron/electronjs.org/issues/new'
+      )
     })
 
     test('redirects /pulls to the website repo, for convenience', async () => {
       const res = await supertest(app).get('/pulls')
       res.statusCode.should.equal(301)
-      res.headers.location.should.equal('https://github.com/electron/electronjs.org/pulls')
+      res.headers.location.should.equal(
+        'https://github.com/electron/electronjs.org/pulls'
+      )
     })
   })
 
@@ -614,12 +709,14 @@ describe('electronjs.org', () => {
           key: process.env.CROWDIN_KEY,
           json: true,
           language: 'zh-CN',
-          file: 'master/content/en-US/docs/api/browser-window.md'
+          file: 'master/content/en-US/docs/api/browser-window.md',
         })
         .once()
         .reply(200, { result: 'mocked' })
 
-      const res = await supertest(app).get('/crowdin/export-file?language=zh-CN&file=master/content/en-US/docs/api/browser-window.md')
+      const res = await supertest(app).get(
+        '/crowdin/export-file?language=zh-CN&file=master/content/en-US/docs/api/browser-window.md'
+      )
       res.statusCode.should.equal(200)
       res.type.should.equal('application/json')
       res.text.should.eq('{"result":"mocked"}')
@@ -656,7 +753,9 @@ describe('electronjs.org', () => {
 
     it('get /service-worker.js', async () => {
       let res = await supertest(app).get('/service-worker.js')
-      res.headers['content-type'].should.equal('application/javascript; charset=UTF-8')
+      res.headers['content-type'].should.equal(
+        'application/javascript; charset=UTF-8'
+      )
     })
 
     describe('node headers', () => {
@@ -673,7 +772,9 @@ describe('electronjs.org', () => {
 
     describe('search redirects', () => {
       it('redirect /search/package to home page search', async () => {
-        const res = await supertest(app).get('/search/npmPackages?q=@siberianmh/cosmos')
+        const res = await supertest(app).get(
+          '/search/npmPackages?q=@siberianmh/cosmos'
+        )
         res.statusCode.should.equal(302)
         res.headers.location.should.equal('/?query=@siberianmh/cosmos')
       })

--- a/test/localization.js
+++ b/test/localization.js
@@ -11,19 +11,29 @@ const flat = require('flat')
 const getProp = require('lodash/get')
 
 const locale = require(path.join(__dirname, '../data/locale.yml'))
-const views = walk.entries(path.join(__dirname, '../views'))
-  .filter(entry => path.extname(entry.relativePath) === '.html')
-  .map(entry => {
+const views = walk
+  .entries(path.join(__dirname, '../views'))
+  .filter((entry) => path.extname(entry.relativePath) === '.html')
+  .map((entry) => {
     const fullPath = path.join(entry.basePath, entry.relativePath)
     const view = {
       relativePath: entry.relativePath,
-      localizedKeys: (fs.readFileSync(fullPath, 'utf8').match(/{{(#each )?(@root\/)?[./]*localized\.[a-z_.]*}}/g) || [])
-        .map(ref => ref.replace(/(\.\.|@root)\//g, '').replace('#each ', '').replace('{{localized.', '').replace('}}', ''))
+      localizedKeys: (
+        fs
+          .readFileSync(fullPath, 'utf8')
+          .match(/{{(#each )?(@root\/)?[./]*localized\.[a-z_.]*}}/g) || []
+      ).map((ref) =>
+        ref
+          .replace(/(\.\.|@root)\//g, '')
+          .replace('#each ', '')
+          .replace('{{localized.', '')
+          .replace('}}', '')
+      ),
     }
     return view
   })
-  .filter(view => view.localizedKeys.length)
-  // console.log(views)
+  .filter((view) => view.localizedKeys.length)
+// console.log(views)
 
 describe('localized views', () => {
   // Find all instances of {{localized.something.something}} in the views
@@ -31,13 +41,16 @@ describe('localized views', () => {
   it('every reference to a localized string is defined', () => {
     views.should.be.an('array')
     views.length.should.be.above(8)
-    views.forEach(view => {
+    views.forEach((view) => {
       view.localizedKeys.length.should.be.above(0)
-      view.localizedKeys.forEach(key => {
+      view.localizedKeys.forEach((key) => {
         // #each is OK
         if (Array.isArray(getProp(locale, key))) return
 
-        expect(getProp(locale, key), `${view.relativePath}: ${key} has no string in locale.yml`).to.be.a('string')
+        expect(
+          getProp(locale, key),
+          `${view.relativePath}: ${key} has no string in locale.yml`
+        ).to.be.a('string')
       })
     })
   })
@@ -45,9 +58,9 @@ describe('localized views', () => {
   // Ensure every string in locale.yml is actually used somewhere
   it('every string in locale.yml is used in a view (except for pages.* and _404.*)', () => {
     const keys = Object.keys(flat(locale))
-      .filter(key => !key.startsWith('pages.'))
-      .filter(key => !key.startsWith('_404.'))
-      .map(key => {
+      .filter((key) => !key.startsWith('pages.'))
+      .filter((key) => !key.startsWith('_404.'))
+      .map((key) => {
         const split = key.split('.')
         // If it is an array index, just check we use the array
         if (/^[0-9]+$/.test(split[split.length - 1])) {
@@ -63,6 +76,11 @@ describe('localized views', () => {
       return acc
     }, [])
 
-    keys.forEach(key => expect(usedKeys, `did not find ${key} in any handlebars template`).to.include(key))
+    keys.forEach((key) =>
+      expect(
+        usedKeys,
+        `did not find ${key} in any handlebars template`
+      ).to.include(key)
+    )
   })
 })


### PR DESCRIPTION
The same what are we do in other repos. Here used `eslint + prettier` instead of single `prettier` for the ability to use rules.