### PR TITLE
feat: add ability to use ga events for analytics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,14 +25,15 @@ feel free to propose changes to this document in a pull request.
 - [Context](#context)
 - [Styles](#styles)
 - [Frontend JavaScript](#frontend-javascript)
+- [GA Evens](#google-analytics-events)
 - [Scripts](#scripts)
 - [Environment Variables](#environment-variables)
 
 ## Issues and Pull Requests
 
-* If you're not sure about adding something, [open an issue](https://github.com/electron/electronjs.org/issues/new) to discuss it.
-* Feel free to open a Pull Request early so that a discussion can be had as changes are developed.
-* Include screenshots and animated gifs of your changes whenever possible.
+- If you're not sure about adding something, [open an issue](https://github.com/electron/electronjs.org/issues/new) to discuss it.
+- Feel free to open a Pull Request early so that a discussion can be had as changes are developed.
+- Include screenshots and animated gifs of your changes whenever possible.
 
 ## Commit Messages and Pull Request Titles
 
@@ -43,7 +44,7 @@ Example: `fix: make header bold`
 
 ### Pull Request Title
 
-Same as commit messages, prepend the type of change being made (refactor, fix, chore, feat, etc.) 
+Same as commit messages, prepend the type of change being made (refactor, fix, chore, feat, etc.)
 Example: `docs: add linux setup instructions`
 
 ## Heroku Review Apps
@@ -82,7 +83,7 @@ You should now have an Express server running at
 
 If there is an error building the `node-sass` dependency, try running `npm rebuild node-sass`.
 
-**Note**: If errors are still shown after you have installed all the dependencies, try to delete the `node_modules` directory in your project and run `npm install` again. 
+**Note**: If errors are still shown after you have installed all the dependencies, try to delete the `node_modules` directory in your project and run `npm install` again.
 
 Read on for more info about the structure of the site.
 
@@ -114,7 +115,7 @@ Blogs are written in "Jekyll style", with YML frontmatter at the top for
 metadata. The `title`, `author`, and `date` properties should be set
 on all posts:
 
-```
+```markdown
 ---
 title: 'I am a blog post'
 author: zeke
@@ -132,9 +133,9 @@ the cutoff point for the post summary that's displayed on the
 
 A few guidelines to keep in mind when publishing a blog post:
 
-* Posts should normally be published on Tuesday mornings (Pacific time) for maximum social reach.
-* Make sure the date in the filename is today's date
-* Tweet about it once the post is live!
+- Posts should normally be published on Tuesday mornings (Pacific time) for maximum social reach.
+- Make sure the date in the filename is today's date
+- Tweet about it once the post is live!
 
 ### Localized Strings
 
@@ -148,7 +149,7 @@ if no translation exists yet.
 To use localized strings in views, use the `localized` object, which is generated
 automatically by the [context middleware](#context):
 
-```html
+```hbs
 <p>{{{localized.web_technologies.description}}}</p>
 ```
 
@@ -340,6 +341,22 @@ document.addEventListener('DOMContentLoaded', () => {
 Like the [Sass middleware](#styles), no compiled JavaScript code is written to
 disk. When a GET request is made to `/scripts/index.js`, the server dynamically
 compiles the `scripts/index.js` file to browser-compatible ES5.
+
+## Google Analytics Events
+
+We use the [Google Analytics Events](https://developers.google.com/analytics/devguides/collection/analyticsjs/events)
+for measure purposes of needing and usage of features what are we
+provide on the website.
+
+For usage, you need to provide the `data-sc-category` and `data-sc-name` properties
+to element. If `data-sc-category` is not provided `general` be used as a
+default category for event.
+
+### Example
+
+```hbs
+<button data-sc-category="docs" data-sc-name="Docs page opening">Open docs page</button>
+```
 
 ## Scripts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ feel free to propose changes to this document in a pull request.
 - [Context](#context)
 - [Styles](#styles)
 - [Frontend JavaScript](#frontend-javascript)
-- [GA Evens](#google-analytics-events)
+- [Google Analytics Events](#google-analytics-events)
 - [Scripts](#scripts)
 - [Environment Variables](#environment-variables)
 
@@ -344,13 +344,12 @@ compiles the `scripts/index.js` file to browser-compatible ES5.
 
 ## Google Analytics Events
 
-We use the [Google Analytics Events](https://developers.google.com/analytics/devguides/collection/analyticsjs/events)
-for measure purposes of needing and usage of features what are we
-provide on the website.
+We use [Google Analytics Events](https://developers.google.com/analytics/devguides/collection/analyticsjs/events)
+to measure usage of features that we provide on the website.
 
-For usage, you need to provide the `data-sc-category` and `data-sc-name` properties
-to element. If `data-sc-category` is not provided `general` be used as a
-default category for event.
+To add an event, you need to provide `data-sc-category` and `data-sc-name`
+properties to an element in the DOM. If `data-sc-category` is not provided,
+`general` will be used as a default category for the event.
 
 ### Example
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -21,4 +21,5 @@ document.addEventListener('DOMContentLoaded', () => {
   require('./language-selector')()
   require('./kb-shortcut-dialog')()
   require('./anchor-links')()
+  require('./science')()
 })

--- a/scripts/science.js
+++ b/scripts/science.js
@@ -1,22 +1,9 @@
-// @ts-check
-
 /**
  * @param {string} category
  * @param {string} action
  */
 const sendScience = (category, action) => {
-  const body = {
-    category: category,
-    action: action,
-  }
-
-  fetch('', {
-    method: 'POST',
-    headers: {
-      'Content-Type': "application/json",
-    },
-    body: JSON.stringify(body)
-  })
+  ga('send', 'event', category, action)
 }
 
 const handleScience = () => {

--- a/scripts/science.js
+++ b/scripts/science.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+/**
+ * @param {string} category
+ * @param {string} action
+ */
+const sendScience = (category, action) => {
+  const body = {
+    category: category,
+    action: action,
+  }
+
+  fetch('', {
+    method: 'POST',
+    headers: {
+      'Content-Type': "application/json",
+    },
+    body: JSON.stringify(body)
+  })
+}
+
+const handleScience = () => {
+  const elements = document.querySelectorAll('[data-sc-name]')
+  elements.forEach((el) => {
+    el.addEventListener('click', () => {
+      const name = el.getAttribute('data-sc-name')
+      let category = el.getAttribute('data-sc-category')
+      if (!category) category = 'general'
+
+      sendScience(category, name)
+    })
+  })
+}
+
+module.exports = handleScience

--- a/views/partials/doc.hbs
+++ b/views/partials/doc.hbs
@@ -1,7 +1,7 @@
 <div class="sub-section position-relative" data-name="{{name}}" data-lang="{{currentLocale}}">
   {{#unless viewingAllDocs}}
     {{#if docEn}}
-      <button class="btn-link position-absolute right-0 mr-2 mt-2 no-underline en-toggle" alt="toggle section language"><h5 class="h5-mktg m-0">EN</h5></button>
+      <button data-sc-category="docs" data-sc-name="Toggle section language" class="btn-link position-absolute right-0 mr-2 mt-2 no-underline en-toggle" alt="toggle section language"><h5 class="h5-mktg m-0">EN</h5></button>
     {{/if}}
   {{/unless}}
   {{{html}}}
@@ -9,7 +9,7 @@
 {{#if docEn}}
   {{#unless viewingAllDocs}}
     <div class="sub-section position-relative hidden" data-name="{{name}}" data-lang="en-US">
-      <button class="btn-link position-absolute right-0 mr-2 mt-2 no-underline en-toggle" alt="toggle section language"><h5 class="h5-mktg m-0">EN</h5></button>
+      <button data-sc-category="docs" data-sc-name="Toggle section language" class="btn-link position-absolute right-0 mr-2 mt-2 no-underline en-toggle" alt="toggle section language"><h5 class="h5-mktg m-0">EN</h5></button>
       {{{docEn.html}}}
     </div>
   {{/unless}}


### PR DESCRIPTION
This PR adds the ability to use the GA Events to future analyzing the needs of features.

## Usage

For usage, you need to pass `data-sc-category` and `data-sc-name` properties to element. If `data-sc-category` not passed `general` be used as a default category.

Example:

```html
<button data-sc-category="docs" data-sc-name="Something happened">Give some magic</button>
```

---

<details>
<summary>
Original PR Description
</summary>

TL;DL: I just wanna known that is useful before remove that 🤷‍♂️

## Why

So, just why not. Mainly I'm unable to make the GA events work. Also, that creates security since only we can see and maintain that data.

## Usage

For usage, you need to pass `data-sc-category` and `data-sc-name` properties to element. If `data-sc-category` not passed `general` be used as a default category.

After clicking sends the request to the metrics server and save the result to the database. See the [Server](#server) section for more info.

Example:

```html
<button data-sc-category="docs" data-sc-name="Something happened">Give some magic</button>
```

## Server

It's currently nothing is created to accept the request on production. But have something like a small implementation.

### Request

For request used the POST request to `/science` path with the next body:

| Name | Description |
| --- | --- |
| action | The description of the event |
| category | The category of the event |

### Database

The database is used to store the data. The schema of the table:

| Name | Type | Description |
| --- | --- | --- |
| id | int | id of event |
| action | text | the description of the event |
| category | varchar(255) | the category for the event  |
| created_at | Date | timestamp when the event is created |

### Grafana or usage of these data

Currently, I do not create a view of that. But something like `All` and `Per day`?

</details>