### PR TITLE
chore: fix `aria-current` option on apps sidebar

### DIFF
--- a/views/apps/index.hbs
+++ b/views/apps/index.hbs
@@ -21,7 +21,7 @@
               {{/if}}
               {{#each categories}}
               <li>
-                <a href="/apps?category={{this.slug}}" class="filter-item {{className}}" aria-current="page"
+                <a href="/apps?category={{this.slug}}" class="filter-item {{className}}" aria-current="{{#if currentCategory}}page{{else}}false{{/if}}"
                   id="category-{{this.slug}}">
                   <span class="count" title="results">{{this.count}}</span>
                   {{this.name}}


### PR DESCRIPTION
Currently, all categories on apps sidebar show as selected. That PR fix that and set the `aria-current` for only selected category. And that side effect from updating Primer to v13 or v14 😑

| Prev | Now |
| --- | --- |
| ![www electronjs org_apps](https://user-images.githubusercontent.com/24681191/87979009-0f80c500-cada-11ea-9c89-1d62e31b2282.png) | ![localhost_5000_apps](https://user-images.githubusercontent.com/24681191/87979019-14457900-cada-11ea-8c2f-7ff866cbdb3a.png) |

And how looks the selected category:

![localhost_5000_apps_category=graphics-design](https://user-images.githubusercontent.com/24681191/87979140-42c35400-cada-11ea-8f67-288a30f30b97.png)

