### PR TITLE
chore: fix the path to screenshot on apps show page

### DIFF
--- a/routes/apps/show.js
+++ b/routes/apps/show.js
@@ -29,10 +29,11 @@ module.exports = (req, res, next) => {
     })
   }
 
-  context.page.image =
+  const appImageUrl =
     app.screenshots && app.screenshots.length
       ? app.screenshots[0].imageUrl
-      : `${req.context.hostname}/images/apps/${app.icon64}`
+      : `${req.context.hostname}/app-img/${app.slug}/${app.icon64}`
+  context.page.image = appImageUrl
 
   if (app.youtube_video_url) {
     context.app.youtube_video_url = app.youtube_video_url.replace(


### PR DESCRIPTION
Currently, when folks post the app URL on like Twitter we show the screenshot of app or icon.

From some old-time we able to show only app screenshot, and not fallback to the icon. This PR changes this behavior and adds the ability to fallback to the icon. 

| Prev | Now |
| --- | --- |
| ![twitter com_compose_tweet (1)](https://user-images.githubusercontent.com/24681191/88090324-179e3a80-cb96-11ea-8e6d-5512b055fa23.png) | ![twitter com_compose_tweet](https://user-images.githubusercontent.com/24681191/88090253-fc332f80-cb95-11ea-9da1-115bbb64df56.png) |