### PR TITLE
chore: switch from process.env.HOST to generic getting of hostname

### DIFF
--- a/middleware/context-builder.js
+++ b/middleware/context-builder.js
@@ -58,6 +58,7 @@ module.exports = function contextBuilder(req, res, next) {
     showAnnouncementBanner: true,
     localized: localized,
     cookies: req.cookies,
+    hostname: `${req.protocol}://${req.get('host')}`,
   }
 
   if (req.path.startsWith('/docs')) {

--- a/routes/apps/show.js
+++ b/routes/apps/show.js
@@ -32,7 +32,7 @@ module.exports = (req, res, next) => {
   context.page.image =
     app.screenshots && app.screenshots.length
       ? app.screenshots[0].imageUrl
-      : `${process.env.HOST}/images/apps/${app.icon64}`
+      : `${req.context.hostname}/images/apps/${app.icon64}`
 
   if (app.youtube_video_url) {
     context.app.youtube_video_url = app.youtube_video_url.replace(

--- a/server.js
+++ b/server.js
@@ -23,7 +23,6 @@ const getOcticons = require('./middleware/register-octicons')
 const port = Number(process.env.PORT) || argv.p || argv.port || 5000
 const app = express()
 const appImgDir = path.resolve(require.resolve('electron-apps'), '..', 'apps')
-process.env.HOST = process.env.HOST || `http://localhost:${port}`
 
 // Handlebars Templates
 hbs.registerHelper(lobars)


### PR DESCRIPTION
Ref #4256 

Changes the getting of host URL from `process.env.HOST` (what seems to die) to generic style, now that support any host. And that thing can be got from `context`: `req.context.hostname` 🙀