### PR TITLE
refactor: switch to use `@primer/css` support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11496,11 +11496,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
     },
-    "primer-support": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-5.0.0.tgz",
-      "integrity": "sha512-inUxVSsGirn5IkPxBhFsMBgm8ZHyfOUmOWyDCN8cBXtbaLiCIAjHsPI46yS1zrWxnn0J2kvq8haomkrlHGF08g=="
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "paginate-array": "^2.1.0",
     "platform-utils": "^1.2.0",
     "pluralize": "^8.0.0",
-    "primer-support": "^5.0.0",
     "query-string": "^6.13.1",
     "require-dir": "^1.1.0",
     "@primer/octicons": "^10.1.0",

--- a/public/styles/index.scss
+++ b/public/styles/index.scss
@@ -22,7 +22,6 @@
 // Components
 @import "../bower_components/primer-css/scss/filter-list";
 @import "../bower_components/basecoat/scss/grid";
-@import "primer-support/index.scss";
 
 // Devicon
 @import "vendor/devicon/devicon.css";
@@ -35,15 +34,17 @@
 // Electron -----------------------------------
 
 @import "base";
-@import "hljs/github.css"; // Syntax highlighting
-@import "hljs/overrides"; // customization
 
 // @primer/css imports
+@import "@primer/css/support/index.scss";
 @import "@primer/css/buttons/index.scss";
 @import "@primer/css/marketing/index.scss";
 @import "@primer/css/tooltips/index.scss";
 @import "@primer/css/utilities/padding.scss";
 @import "@primer/css/pagination/index.scss";
+
+@import "hljs/github.css"; // Syntax highlighting
+@import "hljs/overrides"; // customization
 
 // Basecoat overrides
 @import "./helpers/tables";


### PR DESCRIPTION
This PR replaces the `primer-support` module by the `@primer/css` import. The `hljs` imports moved because they need stuff from the `support` module like new spacers.