### PR TITLE
chore: update getting help section to include discord server

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -71,9 +71,9 @@ community:
       by visiting the
       <a href='/languages'>languages page</a>."
     help:
-      "<a href='https://discuss.atom.io/t/join-us-on-slack/16638'><b>Get help and feedback</b></a>
+      "<a href='https://discord.gg/electron'><b>Get help and feedback</b></a>
       by joining the
-      <a href='https://discuss.atom.io/t/join-us-on-slack/16638'>atomio Slack</a>,
+      <a href='https://discord.gg/electron'>Discord server</a>,
       posting on
       <a href='https://discuss.atom.io/c/electron'>Discuss</a>,
       or visiting

--- a/data/locale.yml
+++ b/data/locale.yml
@@ -71,7 +71,7 @@ community:
       by visiting the
       <a href='/languages'>languages page</a>."
     help:
-      "<a href='https://discord.gg/electron'><b>Get help and feedback</b></a>
+      "<b>Get help and feedback</b>
       by joining the
       <a href='https://discord.gg/electron'>Discord server</a>,
       posting on


### PR DESCRIPTION
This PR updates the link in `/community` from atomio Slack to the Discord server.

Preview: https://electron-website-pr-4589.herokuapp.com/community