### PR TITLE
feat: add a download cta for fiddle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12418,7 +12418,7 @@
       "resolved": "https://registry.npmjs.org/require-yaml/-/require-yaml-0.0.1.tgz",
       "integrity": "sha1-LhsY2RPDuqcqWk03O28Tjd0sMr0=",
       "requires": {
-        "js-yaml": "^3.12.0"
+        "js-yaml": "^3.14.0"
       },
       "dependencies": {
         "esprima": {

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -9,6 +9,46 @@
   </div>
 
 <div class="py-6 py-md-7 py-lg-8">
+  <div class="container-lg p-responsive p-8">
+    <div>
+      <h1 class="f1-light text-center">{{localized.landing.fiddle.lead_desc}}</h1>
+      <div class="d-flex flex-justify-center flex-items-center flex-column flex-md-row pt-8">
+        <div class="d-flex">
+            <img
+              class="fiddle-icon"
+              src="{{ site.baseurl }}/images/fiddle/fiddle-icon.svg"
+              alt="Electron Fiddle Icon"
+            >
+            <img
+              class="ml-5"
+              src="{{ site.baseurl }}/images/fiddle/fiddle-logo.svg"
+              alt="Electron Fiddle"
+            >
+        </div>
+        <div class="ml-md-6 pl-lg-6 mt-6 mt-md-0">
+          <p>
+            <a
+              id="download-latest-release"
+              class="btn-mktg btn-outline-mktg"
+              href="https://github.com/electron/fiddle/releases/latest"
+            >
+              <span class="octicon octicon-desktop-download"></span>
+              <span>{{{localized.download_from_github}}}</span>
+            </a>
+            <a
+              id="download-latest-release"
+              class="btn-mktg btn-outline-mktg"
+              href="/fiddle"
+            >
+              <span class="octicon octicon-info"></span>
+              <span>{{{localized.explore.see_more_info}}}</span>
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <hr class="pt-8">
+  </div>
   <div class="container-lg p-responsive">
     <div>
       <h1 class="f0-light text-center"><a href="/releases/stable">{{localized.nav.releases}}</a></h1>
@@ -129,7 +169,6 @@
     </div>
   </div>
 </div>
-
 
 <div class='py-7 py-md-8 py-lg-9 bg-shade' id='get-started'>
   <div class='container-lg p-responsive text-center'>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -30,6 +30,9 @@
         <div class="dialog-text">Search for Electron APIs, tutorials, npm packages, and apps.</div>
         <button class="dialog-button">OK</button>
       </dialog> -->
+      <a class="site-header-nav-item octicon" href="https://github.com/electron/fiddle/releases/latest" title="Download Electron Fiddle">
+        <span class="mega-octicon octicon-desktop-download vertical-middle"></span>
+      </a>
       <a class="site-header-nav-item octicon" href="https://github.com/electron" title="Github Organization">
         <span class="mega-octicon octicon-mark-github vertical-middle"></span>
       </a>


### PR DESCRIPTION
Resolve #4484 

Add 2 CTA options
- icon in header
- section below hero

![image](https://user-images.githubusercontent.com/3045602/95110694-a0c21800-0768-11eb-897b-0197f40e2d69.png)
![image](https://user-images.githubusercontent.com/3045602/95110728-addf0700-0768-11eb-9eb7-67fee0598eac.png)
