### PR TITLE
docs: improve spectron instructions

### DIFF
--- a/views/spectron.hbs
+++ b/views/spectron.hbs
@@ -59,13 +59,15 @@
 
   <section class='page-section page-section-spacious bg-shade' id='get-started'>
     <div class='container-narrow text-center'>
-      <h1>Get started</h1>
+      <h1>Installation</h1>
       <figure class="highlight highlight-dark text-left my-4">
-      <pre><code><span class="c1"># Install Spectron</span>
-$ npm install --save-dev spectron
+      <pre><code>$ <span class="keyword">npm</span> install --save-dev spectron</code></pre>
+      </figure>
 
-<span class="c1">// A simple test to verify a visible window is opened with a title</span>
-<span class="keyword">var</span> Application = require(<span class="string">'spectron'</span>).Application
+      <h1>Getting started</h1>
+      <p class="lead text-center-sm">The example test below verifies that a visible window is opened with a title.</p>
+      <figure class="highlight highlight-dark text-left my-4">
+      <pre><code><span class="keyword">var</span> Application = require(<span class="string">'spectron'</span>).Application
 <span class="keyword">var</span> assert = require(<span class="string">'assert'</span>)
 
 <span class="keyword">var</span> app = <span class="keyword">new</span> Application({


### PR DESCRIPTION
Broke up the documentation and added highlighting to the installation instructions as requested in #4537

Let me know if this is what you were looking for.

<img width="979" alt="image" src="https://user-images.githubusercontent.com/19378484/95513279-17892c00-0988-11eb-835f-d3895fc2b33e.png">
