### PR TITLE
docs: add copy button to spectron and devtron code blocks

### DIFF
--- a/public/styles/helpers/_code.scss
+++ b/public/styles/helpers/_code.scss
@@ -54,16 +54,17 @@ h4 {
 
   pre {
     padding: $spacer-3;
+    position: relative;
     overflow: visible;
     font-size: 16px;
     line-height: 1.45;
 
     code {
-      display: block;
+      display: inline;
       max-width: initial;
       padding: 0;
       margin: 0;
-      overflow: scroll;
+      overflow: initial;
       line-height: inherit;
       word-wrap: normal;
       background-color: transparent;

--- a/public/styles/helpers/_code.scss
+++ b/public/styles/helpers/_code.scss
@@ -54,16 +54,16 @@ h4 {
 
   pre {
     padding: $spacer-3;
-    overflow: auto;
+    overflow: visible;
     font-size: 16px;
     line-height: 1.45;
 
     code {
-      display: inline;
+      display: block;
       max-width: initial;
       padding: 0;
       margin: 0;
-      overflow: initial;
+      overflow: scroll;
       line-height: inherit;
       word-wrap: normal;
       background-color: transparent;

--- a/views/devtron.hbs
+++ b/views/devtron.hbs
@@ -79,10 +79,10 @@
   </section>
 
   <section class='page-section page-section-spacious bg-shade' id='get-started'>
-    <div class='container-narrow text-center'>
+    <div class='container-narrow text-center markdown-body'>
       <h1>Get started</h1>
       <figure class="highlight highlight-dark text-left my-4">
-      <pre><code><span class="c1"># Install Devtron</span>
+      <pre><code class="hljs"><span class="c1"># Install Devtron</span>
 $ npm install --save-dev devtron
 
 <span class="c1">// Run the following from the Console tab of your app's DevTools</span>

--- a/views/spectron.hbs
+++ b/views/spectron.hbs
@@ -58,16 +58,16 @@
   </section>
 
   <section class='page-section page-section-spacious bg-shade' id='get-started'>
-    <div class='container-narrow text-center'>
+    <div class='container-narrow text-center markdown-body'>
       <h1>Installation</h1>
       <figure class="highlight highlight-dark text-left my-4">
-      <pre><code>$ <span class="keyword">npm</span> install --save-dev spectron</code></pre>
+      <pre><code class="hljs">$ <span class="keyword">npm</span> install --save-dev spectron</code></pre>
       </figure>
 
       <h1>Getting started</h1>
       <p class="lead text-center-sm">The example test below verifies that a visible window is opened with a title.</p>
       <figure class="highlight highlight-dark text-left my-4">
-      <pre><code><span class="keyword">var</span> Application = require(<span class="string">'spectron'</span>).Application
+      <pre><code class="hljs"><span class="keyword">var</span> Application = require(<span class="string">'spectron'</span>).Application
 <span class="keyword">var</span> assert = require(<span class="string">'assert'</span>)
 
 <span class="keyword">var</span> app = <span class="keyword">new</span> Application({


### PR DESCRIPTION
See #4617 

<img width="941" alt="image" src="https://user-images.githubusercontent.com/19378484/95524902-a0ac5d00-09a0-11eb-875b-1dac68fc58c4.png">
