### PR TITLE
fix: correctly detect if a post does not exist

### DIFF
--- a/routes/blog/show.js
+++ b/routes/blog/show.js
@@ -14,8 +14,9 @@ function hydrateViewModel(blogPost) {
 
 module.exports = async (req, res, next) => {
   const blogPost = BlogPost.get(req.params.slug, req.language)
-  const exists = await blogPost.exists()
-  if (!exists) {
+  try {
+    await blogPost.exists()
+  } catch (e) {
     return next()
   }
 


### PR DESCRIPTION
`await fs.stat` returns an exception that is not captured and thus stopping the whole process.