### PR TITLE
chore: ignore webpack precompile in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,4 +4,5 @@ module.exports = {
     sourceType: 'module',
   },
   extends: ['prettier', 'plugin:prettier/recommended'],
+  ignorePatterns: ['precompiled/**/*.js'],
 }


### PR DESCRIPTION
This is a file generated by webpack and makes linting incredibly slow.