### PR TITLE
feat: Update command to install brew casks

### DIFF
--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -111,7 +111,7 @@
           {{#if app.homebrewCaskName}}
             <div class="darwin-only app-meta-entry">
               <h5 class="mb-2 text-mono text-normal text-gray-light">Homebrew</h5>
-              <span class="shell-one-liner app-download-input">brew cask install {{app.homebrewCaskName}}</span>
+              <span class="shell-one-liner app-download-input">brew install --cask {{app.homebrewCaskName}}</span>
             </div>
           {{/if}}
 


### PR DESCRIPTION
It looks like the way to install a cask with homebrew recently changed.

Running `brew cask install gitify`, would error with:
```
gitify > brew cask install gitify
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

The new way of installing a cask would be by passing --cask as a flag.
```
brew install --cask gitify
```