### PR TITLE
fix: table of contents style adjustments

### DIFF
--- a/public/styles/_docs.scss
+++ b/public/styles/_docs.scss
@@ -28,11 +28,12 @@
   .docs__nav-wrapper {
     position: -webkit-sticky; /* Safari */
     position: sticky;
-    top: $spacer-4;
+    top: 0;
   }
 
   .docs__nav {
     overflow-y: auto;
+    padding-top: $spacer-6;
     max-height: 100vh;
 
     h1 {

--- a/views/layouts/docs.hbs
+++ b/views/layouts/docs.hbs
@@ -56,12 +56,11 @@
     {{{body}}}
   </div>
 
-  <div class="hide-sm hide-md hide-lg col-lg-4 col-xl-3 pt-4">
+  <div class="hide-sm hide-md hide-lg col-lg-4 col-xl-3">
     <!-- Right Column -->
     {{#if isDocPage}} <!-- if generated from docs/show.js -->
     <div class="docs__nav-wrapper">
       <nav class="docs__nav">
-        <h1>Table of Contents</h1>
         <div class="docs__table-of-contents pb-12">
 
         </div>


### PR DESCRIPTION
* Fixes padding for the table of contents navigation such that you can now see the bottom of the scrollbar when the nav overflows.
* Removes `Table of Contents` heading element.