### PR TITLE
chore: add Flash removal, SSE3 requirement to Electron 12 blog

### DIFF
--- a/data/blog/electron-12-0.md
+++ b/data/blog/electron-12-0.md
@@ -43,7 +43,7 @@ See the [12.0.0 release notes](https://github.com/electron/electron/releases/tag
 * Changed the default value of `contextIsolation` to `true`. [#27949](https://github.com/electron/electron/pull/27949) 
 * Changed the default value of `worldSafeExecuteJavaScript` to `true`. [#27502](https://github.com/electron/electron/pull/27502) 
 * Changed the default of `crashReporter.start({ compress })` from `false` to `true`. [#25288](https://github.com/electron/electron/pull/25288) 
-* Removed Flash support: Chromium has removed support for Flash, which was aso removed in Electron 12. See [Chromium's Flash Roadmap](https://www.chromium.org/flash-roadmap) for more details.
+* Removed Flash support: Chromium has removed support for Flash, which was also removed in Electron 12. See [Chromium's Flash Roadmap](https://www.chromium.org/flash-roadmap) for more details.
 * Required SSE3 for Chrome on x86: Chromium has removed support for [older x86 CPUs that do not meet a minimum of SSE3 (Supplemental Streaming SIMD Extensions 3) support](https://docs.google.com/document/d/1QUzL4MGNqX4wiLvukUwBf6FdCL35kCDoEJTm2wMkahw/edit#heading=h.7nki9mck5t64). This support was also removed in Electron 12.
 
 More information about these and future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/master/docs/breaking-changes.md) page.

--- a/data/blog/electron-12-0.md
+++ b/data/blog/electron-12-0.md
@@ -43,6 +43,8 @@ See the [12.0.0 release notes](https://github.com/electron/electron/releases/tag
 * Changed the default value of `contextIsolation` to `true`. [#27949](https://github.com/electron/electron/pull/27949) 
 * Changed the default value of `worldSafeExecuteJavaScript` to `true`. [#27502](https://github.com/electron/electron/pull/27502) 
 * Changed the default of `crashReporter.start({ compress })` from `false` to `true`. [#25288](https://github.com/electron/electron/pull/25288) 
+* Removed Flash support: Chromium has removed support for Flash, which was aso removed in Electron 12. See [Chromium's Flash Roadmap](https://www.chromium.org/flash-roadmap) for more details.
+* Required SSE3 for Chrome on x86: Chromium has removed support for [older x86 CPUs that do not meet a minimum of SSE3 (Supplemental Streaming SIMD Extensions 3) support](https://docs.google.com/document/d/1QUzL4MGNqX4wiLvukUwBf6FdCL35kCDoEJTm2wMkahw/edit#heading=h.7nki9mck5t64). This support was also removed in Electron 12.
 
 More information about these and future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/master/docs/breaking-changes.md) page.
 


### PR DESCRIPTION
Small PR that adds two removed/breaking changes to the Electron blog:

- Removed Flash Support
- Required SSE3 for Chrome on x86