### PR TITLE
fix: more semantic HTML on Releases page

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -223,18 +223,18 @@ describe('electronjs.org', () => {
       cy.get('.r-resp-header-toggle').should('be.visible').click()
 
       cy.get('#release-navbar').should('not.have.class', 'd-none')
-      cy.get('#release-navbar > h3')
+      cy.get('#release-navbar > h1')
         .should('be.visible')
         .contains('Show Releases:')
     })
 
     // FIXME: expected '' to equal 301
-    // xit('/docs/versions redirects to /releases/stable', async () => {
-    //   cy.visit(`${localhost}/docs/versions`).then((res) => {
-    //     expect(res.status).to.eq(301)
-    //     expect(res.redirectedToUrl).to.eq(`${localhost}/releases/stable`)
-    //   })
-    // })
+    it('/docs/versions redirects to /releases/stable', async () => {
+      cy.visit(`${localhost}/docs/versions`).then((res) => {
+        expect(res.status).to.eq(301)
+        expect(res.redirectedToUrl).to.eq(`${localhost}/releases/stable`)
+      })
+    })
   })
 
   /**

--- a/public/styles/_releases.scss
+++ b/public/styles/_releases.scss
@@ -53,11 +53,10 @@
       background-color: $gray-0;
     }
 
-    &.selected {
+    &.active {
       font-weight: bold;
-      color: $gray-7;
-      cursor: default;
-      background-color: $white;
+      background-color: $gray-0;
+      border-left: 2px solid $main-link-color;
     }
 
     .octicon {

--- a/public/styles/_releases.scss
+++ b/public/styles/_releases.scss
@@ -111,6 +111,12 @@
       font-style: normal;
     }
   }
+
+  .release-notes {
+    border-bottom: 1px solid $gray-0;
+    margin-bottom: 48px;
+    padding-bottom: 48px;
+  }
 }
 
 @media (min-width: 700px) {

--- a/views/releases/index.hbs
+++ b/views/releases/index.hbs
@@ -8,7 +8,7 @@
     </div>
 
     <nav id="release-navbar" class="r-resp-header d-none site-header-nav">
-      <h3>{{localized.releases.show_releases}}</h3>
+      <h1>{{localized.releases.show_releases}}</h1>
       <a class="releases-link-stable {{#eq releasesPage.type 'stable'}}active{{/eq}}" href="/releases/stable">
         <div class="menu-item" style="{{#eq releasesPage.type 'stable'}}border-left: 1px solid #4078C0; background: #fcfcfc{{/eq}}">
           <span class="octicon octicon-clock"></span>{{localized.releases.stable_releases}}
@@ -40,17 +40,6 @@
 
 <section class='page-section'>
   <div class='docs-container-xl r-flex'>
-    <!-- <h3>Tip: Use Electron from the command line</h3>
-    <p>Installing the <code>electron</code> module as a development dependency in your project will let you use Electron from the command line at specific versions. More information on the <a href="https://github.com/electron-userland/electron-prebuilt">module's repository</a>.</p>
-
-    <figure class="highlight highlight-dark text-left my-4">
-      <pre><code>$ npm install --save-dev electron
-<span class="c1"># Launch from inside your project's directory:</span>
-$ ./node_modules/.bin/electron .</code></pre>
-    </figure>
-
-    <hr> -->
-
     <div class="releases">
       {{#eq releasesPage.page.data.length 0}}
         <h2>No releases matching the current filters</h2>
@@ -68,40 +57,41 @@ $ ./node_modules/.bin/electron .</code></pre>
           <a href="{{this.data.html_url}}" class="tag octicon-wrapper"><span class="octicon octicon-mark-github vertical-middle"></span></a>
         </h2>
 
-        {{{this.data.body_html}}}
-
+        <article>
+          {{{this.data.body_html}}}
+        </article>
         <hr>
       {{/each}}
     </div>
     <div>
-      <div class="r-menu">
-        <h3>{{localized.releases.show_releases}}</h3>
-        <a class="releases-link-stable {{#eq releasesPage.type 'stable'}}active{{/eq}}" href="/releases/stable">
-          <div class="menu-item" style="{{#eq releasesPage.type 'stable'}}border-left: 1px solid #4078C0; background: #fcfcfc{{/eq}}">
+      <nav class="r-menu">
+        <strong>{{localized.releases.show_releases}}</strong>
+        <a class="releases-link-stable" href="/releases/stable">
+          <div class="menu-item {{#eq releasesPage.type 'stable'}}active{{/eq}}">
             <span class="octicon octicon-clock"></span>{{localized.releases.stable_releases}}
             <p>{{localized.releases.stable_desc}}</p>
           </div>
         </a>
-        <a class="releases-link-beta {{#eq releasesPage.type 'beta'}}active{{/eq}}" href="/releases/beta">
-          <div class="menu-item" style="{{#eq releasesPage.type 'beta'}}border-left: 1px solid #4078C0; background: #fcfcfc{{/eq}}">
+        <a class="releases-link-beta" href="/releases/beta">
+          <div class="menu-item {{#eq releasesPage.type 'beta'}}active{{/eq}}">
             <span class="octicon octicon-zap"></span>{{localized.releases.beta_releases}}
             <p>{{localized.releases.beta_desc}}</p>
           </div>
         </a>
-        <a class="releases-link-nightly {{#eq releasesPage.type 'nightly'}}active{{/eq}}" href="/releases/nightly">
-          <div class="menu-item" style="{{#eq releasesPage.type 'nightly'}}border-left: 1px solid #4078C0; background: #fcfcfc{{/eq}}">
+        <a class="releases-link-nightly" href="/releases/nightly">
+          <div class="menu-item {{#eq releasesPage.type 'nightly'}}active{{/eq}}">
             <span class="octicon octicon-calendar"></span>{{localized.releases.nightly_releases}}
             <p>{{localized.releases.nightly_desc}}</p>
           </div>
         </a>
-        <h3>{{localized.releases.show_only_releases_from}}</h3>
+        <strong>{{localized.releases.show_only_releases_from}}</strong>
         <ul class="release-version-filter">
           <li><a class="{{#eq @root/releasesPage.versionFilter null}}active{{/eq}}" href="?">{{localized.releases.all_versions}}</a></li>
           {{#each releasesPage.majorVersions}}
             <li><a class="{{#eq @root/releasesPage.versionFilter this}}active{{/eq}}" href="?version={{this}}">v{{this}}.x</a></li>
           {{/each}}
         </ul>
-      </div>
+      </nav>
     </div>
   </div>
 

--- a/views/releases/index.hbs
+++ b/views/releases/index.hbs
@@ -50,7 +50,7 @@
       {{/if}}
 
       {{#each releasesPage.page.data}}
-        <article>
+        <article class="release-notes">
           <h1 class="release-entry" id="{{this.data.version}}">
             <a class="tag" href="#{{this.data.version}}">Electron {{this.data.version}}</a>
             <em class="date" data-date="{{this.data.published_at}}" data-format="%B %d, %Y">{{this.data.published_at}}</em>

--- a/views/releases/index.hbs
+++ b/views/releases/index.hbs
@@ -59,7 +59,6 @@
           </h1>
           {{{this.data.body_html}}}
         </article>
-        <hr>
       {{/each}}
     </div>
     <div>

--- a/views/releases/index.hbs
+++ b/views/releases/index.hbs
@@ -50,14 +50,13 @@
       {{/if}}
 
       {{#each releasesPage.page.data}}
-        <h2 class="release-entry" id="{{this.data.version}}">
-          <a class="tag" href="#{{this.data.version}}">Electron {{this.data.version}}</a>
-          <em class="date" data-date="{{this.data.published_at}}" data-format="%B %d, %Y">{{this.data.published_at}}</em>
-          <em class="date ltr-only">(<span data-date="{{this.data.published_at}}"></span>)</em>
-          <a href="{{this.data.html_url}}" class="tag octicon-wrapper"><span class="octicon octicon-mark-github vertical-middle"></span></a>
-        </h2>
-
         <article>
+          <h1 class="release-entry" id="{{this.data.version}}">
+            <a class="tag" href="#{{this.data.version}}">Electron {{this.data.version}}</a>
+            <em class="date" data-date="{{this.data.published_at}}" data-format="%B %d, %Y">{{this.data.published_at}}</em>
+            <em class="date ltr-only">(<span data-date="{{this.data.published_at}}"></span>)</em>
+            <a href="{{this.data.html_url}}" class="tag octicon-wrapper"><span class="octicon octicon-mark-github vertical-middle"></span></a>
+          </h1>
           {{{this.data.body_html}}}
         </article>
         <hr>


### PR DESCRIPTION
A couple things here:
* Adding an `<article>` tag around each set of release notes to prevent multiple `<h1>` level tags in a single page context.
* Removing stray `<h3>` tags that were placed ostensibly for visual effect.
* Making the release line menu a `<nav>`.
* Removing `style` attributes on the release line menu, instead putting them in the stylesheet.