### PR TITLE
chore: remove links to `discuss.atom.io`

### DIFF
--- a/data/locale.yml
+++ b/data/locale.yml
@@ -71,8 +71,6 @@ community:
       "<b>Get help and feedback</b>
       by joining the
       <a href='https://discord.gg/electron'>Discord server</a>,
-      posting on
-      <a href='https://discuss.atom.io/c/electron'>Discuss</a>,
       or visiting
       <a href='https://stackoverflow.com/questions/tagged/electron'>Stack Overflow</a>."
     security:
@@ -206,7 +204,7 @@ quick_start:
 
 need_help:
   title: Need Help?
-  description: Ask questions in the <a href='https://discuss.atom.io/c/electron'>Discuss</a> forum. Follow <a href="https://twitter.com/electronjs">@electronjs</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:info@electronjs.org">info@electronjs.org</a>.
+  description: Ask questions in the <a href='https://discord.gg/electron'>Discord server</a>. Follow <a href="https://twitter.com/electronjs">@electronjs</a> on Twitter for important announcements. Need to privately reach out? Email <a href="mailto:info@electronjs.org">info@electronjs.org</a>.
 
 headings:
   languages: Languages


### PR DESCRIPTION
The `discuss.atom.io` give the SSL cert error, and the http connection now redirect to the `atom/atom` repo, so it's better to remove them since we have a beautiful Discord server