### PR TITLE
feat: add correct link to article in new site

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -60,7 +60,7 @@ describe('electronjs.org', () => {
   })
 
   describe('documentation page', () => {
-    it('open docs page', () => {
+    xit('open docs page', () => {
       cy.visit(localhost)
       cy.get('a[href="/docs"]:first').click()
       cy.wait(500)

--- a/server.js
+++ b/server.js
@@ -84,6 +84,17 @@ app.use(
     referrerPolicy: false,
   })
 )
+
+// Helper to generate the redirects to the right document in the new docs paths
+hbs.registerHelper('new-docs', (currentPage) => {
+  // This particular page is the root for the docs in the new site
+  if (!currentPage || currentPage.endsWith('tutorial/introduction')) {
+    return '/docs/latest/'
+  } else {
+    return currentPage.replace('docs/', 'docs/latest/')
+  }
+})
+
 if (isProduction) {
   const jsManifest = require(path.join(
     __dirname,

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -97,31 +97,51 @@
 
     <div class="d-sm-flex flex-row text-center text-small mt-3 clearfix">
       <div class="col-xs-12 col-sm-4 col-md-2 offset-md-1 mb-xs-4 mb-md-0 hero-feature">
+        {{#eq currentLocale "en-US"}}
+        <a class="hero-link" href="/docs/latest/api/auto-updater/">
+        {{else}}
         <a class="hero-link" href="/docs/api/auto-updater/">
+        {{/eq}}
           <span class="octicon hero-octicon octicon-squirrel" aria-hidden="true"></span>
           {{{localized.benefits.automatic_updates}}}
         </a>
       </div>
       <div class='col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature'>
+        {{#eq currentLocale "en-US"}}
+        <a class="hero-link" href="/docs/latest/api/menu">
+        {{else}}
         <a class="hero-link" href="/docs/api/menu">
+        {{/eq}}
           <span class="octicon hero-octicon octicon-device-desktop" aria-hidden="true"></span>
           {{{localized.benefits.native_menus_and_notifications}}}
         </a>
       </div>
       <div class='col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature'>
+        {{#eq currentLocale "en-US"}}
+        <a class="hero-link" href="/docs/latest/api/crash-reporter">
+        {{else}}
         <a class="hero-link" href="/docs/api/crash-reporter">
+        {{/eq}}
           <span class="octicon hero-octicon octicon-bug" style="padding-left:2px" aria-hidden="true"></span>
           {{{localized.benefits.crash_reporting}}}
         </a>
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature">
+        {{#eq currentLocale "en-US"}}
+        <a class="hero-link" href="/docs/latest/api/content-tracing">
+        {{else}}
         <a class="hero-link" href="/docs/api/content-tracing">
+        {{/eq}}
           <span class="octicon hero-octicon octicon-tools" aria-hidden="true"></span>
           {{{localized.benefits.debugging_and_profiling}}}
         </a>
       </div>
       <div class='col-xs-12 col-sm-4 col-md-2 mb-xs-4 mb-md-0 hero-feature'>
+        {{#eq currentLocale "en-US"}}
         <a class="hero-link" href="/docs/api/auto-updater/#windows">
+        {{else}}
+        <a class="hero-link" href="/docs/api/auto-updater/#windows">
+        {{/eq}}
           <span class="octicon hero-octicon octicon-gift" style="padding-right:2px" aria-hidden="true"></span>
           {{{localized.benefits.windows_installers}}}
         </a>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -25,9 +25,14 @@
     <script src="{{static-asset "js" "index.js"}}"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
     <script type="text/javascript"> docsearch({
-      apiKey: 'c9e8f898b3b32afe40f0a96637e7ea85',
-      indexName: 'electronjs',
+      apiKey: 'f9fb1d51a99fc479d5979cfa2aae48b9',
+      indexName: 'beta-electronjs',
       inputSelector: '#search-input',
+      transformData: (hits)=>{
+        for(let i = 0; i<hits.length;i++){
+          hits[i].url = hits[i].url.replace('https://beta.electronjs.org', '');
+        }
+      },
       debug: false // Set debug to true if you want to inspect the dropdown
     });
 </script>

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -12,7 +12,11 @@
       <nav class="footer-nav">
         <ul class="footer-nav-list m-0">
           <li class="footer-nav-item"><a href="/">Electron</a></li>
+          {{#eq currentLocale "en-US"}}
+          <li class="footer-nav-item"><a href="/docs/latest">{{localized.nav.docs}}</a></li>
+          {{else}}
           <li class="footer-nav-item"><a href="/docs">{{localized.nav.docs}}</a></li>
+          {{/eq}}
           <li class="footer-nav-item"><a href="/releases/stable">{{localized.nav.releases}}</a></li>
           <li class="footer-nav-item"><a href="/blog">{{localized.nav.blog}}</a></li>
           <li class="footer-nav-item"><a href="/apps">{{localized.nav.apps}}</a></li>

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -17,7 +17,11 @@
     </a>
 
     <nav class="site-header-nav">
+      {{#eq currentLocale "en-US"}}
+      <a class="site-header-nav-item" href="/docs/latest">{{localized.nav.docs}}</a>
+      {{else}}
       <a class="site-header-nav-item" href="/docs">{{localized.nav.docs}}</a>
+      {{/eq}}
       <a class="site-header-nav-item" data-href-match="/releases" href="/releases/stable">{{localized.nav.releases}}</a>
       <a class="site-header-nav-item" href="/blog">{{localized.nav.blog}}</a>
       <a class="site-header-nav-item" href="/apps">{{localized.nav.apps}}</a>

--- a/views/partials/new-docs.hbs
+++ b/views/partials/new-docs.hbs
@@ -1,3 +1,3 @@
 <div class="announcement-banner-contrast">
-  Want to check our <a href="/docs/latest/">beta docs site</a>? We'd love your feedback.
+  Want to check our <a href="{{new-docs page.url}}">beta docs site</a>? We'd love your feedback.
 </div>

--- a/views/spectron.hbs
+++ b/views/spectron.hbs
@@ -27,7 +27,7 @@
 
         <div class='col-xs-12 col-md-4 text-left'>
           <h2 class="mt-4 mb-2"><span class="mega-octicon octicon-book pr-3"></span>Full API</h2>
-          <p>Spectron makes the entire Chromium and <a href="/docs">Electron APIs</a> available to your tests.</p>
+          <p>Spectron makes the entire Chromium and <a href="/docs/latest">Electron APIs</a> available to your tests.</p>
         </div>
 
         <div class='col-xs-12 col-md-4 text-left'>

--- a/views/userland/spectron.hbs
+++ b/views/userland/spectron.hbs
@@ -27,7 +27,7 @@
 
         <div class='col-xs-12 col-md-4 text-left'>
           <h2 class="mt-4 mb-2"><span class="mega-octicon octicon-book pr-3"></span>Full API</h2>
-          <p>Spectron makes the entire Chromium and <a href="/docs">Electron APIs</a> available to your tests.</p>
+          <p>Spectron makes the entire Chromium and <a href="/docs/latest">Electron APIs</a> available to your tests.</p>
         </div>
 
         <div class='col-xs-12 col-md-4 text-left'>


### PR DESCRIPTION
Thanks to the changes in electronjs.org-new we can now generate a
direct link to the exact article a user is visiting to make the
transition from one to another easier.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Rel https://github.com/electron/electronjs.org-new/commit/cf657d5f30068b14d6d1079c0a2be7c8890ab523