### PR TITLE
chore: redirect to new docs site for any route

### DIFF
--- a/cypress/integration/actions.js
+++ b/cypress/integration/actions.js
@@ -59,7 +59,7 @@ describe('electronjs.org', () => {
     })
   })
 
-  describe('documentation page', () => {
+  describe.skip('documentation page', () => {
     xit('open docs page', () => {
       cy.visit(localhost)
       cy.get('a[href="/docs"]:first').click()
@@ -68,7 +68,7 @@ describe('electronjs.org', () => {
       cy.get('.container-lg').contains('Electron Documentation')
     })
 
-    it('documentation page has guides, api references, and advanced sections', () => {
+    xit('documentation page has guides, api references, and advanced sections', () => {
       cy.visit(`${localhost}/docs`)
       cy.wait(500)
       cy.get('a[href="/docs/tutorial"]').contains('Guides')
@@ -208,7 +208,7 @@ describe('electronjs.org', () => {
     })
 
     // FIXME: expected '' to equal 301
-    it('/docs/versions redirects to /releases/stable', async () => {
+    xit('/docs/versions redirects to /releases/stable', async () => {
       cy.visit(`${localhost}/docs/versions`).then((res) => {
         expect(res.status).to.eq(301)
         expect(res.redirectedToUrl).to.eq(`${localhost}/releases/stable`)

--- a/server.js
+++ b/server.js
@@ -208,7 +208,17 @@ app.get('/contact', (req, res) => res.redirect(301, '/community'))
 app.use('/crowdin', routes.languages.proxy)
 app.get('/devtron', routes.devtron)
 app.use('/docs', feedback)
-app.get('/docs', routes.docs.index)
+// The documentation is served elsewhere, see electron/electronjs.org-new
+// Moving all users landing directly in an old "docs" route to the new one
+app.get('/docs', (req, res) => res.redirect(301, '/docs/latest'))
+app.get('/docs/:path', (req, res, next) => {
+  if (req.params.path !== 'latest') {
+    res.redirect(301, `/docs/latest/${req.params.path}`)
+  } else {
+    next()
+  }
+})
+// The requests to the following docs routes should be intercepted by Fastly and never reach
 app.get('/docs/versions', (req, res) => res.redirect(301, '/releases/stable'))
 app.get('/docs/:category', routes.docs.category)
 app.get('/docs/api/structures', routes.docs.structures)
@@ -249,9 +259,6 @@ app.get('/pulls', (req, res) =>
 
 // Redirected old paths
 app.get('/awesome', (req, res) => res.redirect('/community'))
-app.get('/docs/latest*', (req, res) =>
-  res.redirect(req.path.replace(/^\/docs\/latest/gi, '/docs'))
-)
 app.get('/docs/v0*', (req, res) =>
   res.redirect(req.path.replace(/^\/docs\/v0\.\d+\.\d+/gi, '/docs'))
 )

--- a/test/index.js
+++ b/test/index.js
@@ -179,7 +179,7 @@ describe('electronjs.org', () => {
     })
   })
 
-  describe('docs', () => {
+  describe.skip('docs', () => {
     test('index', async () => {
       const $ = await get('/docs')
       $('header').should.have.class('site-header')
@@ -422,7 +422,7 @@ describe('electronjs.org', () => {
       })
     })
 
-    test('/docs/versions redirects to /releases/stable', async () => {
+    test.skip('/docs/versions redirects to /releases/stable', async () => {
       const res = await supertest(app).get('/docs/versions')
       res.statusCode.should.be.equal(301)
       res.headers.location.should.equal('/releases/stable')
@@ -513,7 +513,7 @@ describe('electronjs.org', () => {
       $('body').text().should.include('global developer community')
     })
 
-    test('language query param for one-off viewing in other languages', async () => {
+    test.skip('language query param for one-off viewing in other languages', async () => {
       const frenchContent = 'fenêtres'
       const sesh = session(app)
 
@@ -527,7 +527,7 @@ describe('electronjs.org', () => {
       $('blockquote').text().should.not.include(frenchContent)
     })
 
-    test('incompleted language query param redirects with the correct language', async () => {
+    test.skip('incompleted language query param redirects with the correct language', async () => {
       // Missing region
       let res = await supertest(app).get('/docs/api/browser-window?lang=fr')
       res.statusCode.should.be.equal(302)
@@ -548,7 +548,7 @@ describe('electronjs.org', () => {
       res.headers.location.should.equal('/docs/api/browser-window?lang=es-ES')
     })
 
-    test('language query param wont redirects with the correct language', async () => {
+    test.skip('language query param wont redirects with the correct language', async () => {
       // without language query is not redirected (200)
       let res = await supertest(app).get('/docs/api/browser-window')
       res.statusCode.should.be.equal(200)


### PR DESCRIPTION
Redirect to `/latest/` routes now that the localized content is
available.