### PR TITLE
docs: add China community slack link

### DIFF
--- a/views/community.hbs
+++ b/views/community.hbs
@@ -34,6 +34,7 @@
       <li><a href="https://electron-tr.herokuapp.com" rel="nofollow">electron-tr</a> <em>(Turkish)</em></li>
       <li><a href="https://electron-id.slack.com" rel="nofollow">electron-id</a> <em>(Indonesia)</em></li>
       <li><a href="https://electronpl.github.io" rel="nofollow">electron-pl</a> <em>(Poland)</em></li>
+      <li><a href="https://electron-zh.slack.com" rel="nofollow">electron-zh</a> <em>(China)</em></li>
     </ul>
   </div>
 


### PR DESCRIPTION
We are landing on the current version first and the `/community` page of the new version of the official website will be modified in https://github.com/electron/electronjs.org-new/pull/133.

cc: @erickzhao 