### PR TITLE
fix: whole word only discord link replacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "webpack-manifest-plugin": "^4.0.2"
   },
   "engines": {
-    "node": ">=12 <15"
+    "node": ">=12"
   },
   "lint-staged": {
     "*.js": "npm run lint:js",

--- a/server.js
+++ b/server.js
@@ -111,9 +111,12 @@ hbs.registerHelper('to2CharLocale', (locale) => {
   }
 })
 
-hbs.registerHelper('replace', function (find, replace, options) {
+hbs.registerHelper('replace', function (options) {
   const string = options.fn(this)
-  return string.replace(find, replace)
+  return string.replace(
+    new RegExp(`\\bhttps:\/\/discord\.gg/electron\\b`, 'g'),
+    'https://discord.gg/electronjs'
+  )
 })
 
 if (isProduction) {

--- a/views/community.hbs
+++ b/views/community.hbs
@@ -11,7 +11,7 @@
   <div class="container-lg p-responsive">
     <p class="lead mb-4">🐎 {{{localized.community.channels.get_started}}}</p>
     <p class="lead mb-4">📣 {{{localized.community.channels.updates}}}</p>
-    <p class="lead mb-4">{{#replace "discord.gg/electron" "discord.gg/electronjs"}}{{{localized.community.channels.help}}}{{/replace}}</p>
+    <p class="lead mb-4">{{#replace}}{{{localized.community.channels.help}}}{{/replace}}</p>
     <p class="lead mb-4">🌍 {{{localized.community.channels.localized_docs}}}</p>
     <p class="lead mb-4">🔒 {{{localized.community.channels.security}}}</p>
     <p class="lead mb-4">🐞 {{{localized.community.channels.bugs}}}</p>

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -229,7 +229,7 @@
 
 
     <h3 class="f2-light pt-4">{{{localized.need_help.title}}}</h3>
-    <p>{{#replace "discord.gg/electron" "discord.gg/electronjs"}}{{{localized.need_help.description}}}{{/replace}}</p>
+    <p>{{#replace}}{{{localized.need_help.description}}}{{/replace}}</p>
 
   </div>
 </div>


### PR DESCRIPTION
the replace function was naive and replaced `https://discord.gg/electronjs` with `https://discord.gg/electronjsjs`