### PR TITLE
fix: proper node engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "webpack-manifest-plugin": "^4.0.2"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=12 <17"
   },
   "lint-staged": {
     "*.js": "npm run lint:js",


### PR DESCRIPTION
Regression from https://github.com/electron/electronjs.org/pull/5936 and Heroku doesn't let you only specify a > in the engines range.